### PR TITLE
Handle 2020 service berlin page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+/vendor

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TerminDe
 
-Simple Termin cancelation monitoring :eyeglasses:
+Simple Termin cancelation monitoring for the Berliner offices :eyeglasses:
 
 ## Installation
 
@@ -21,21 +21,29 @@ Or install it yourself as:
 ## Usage
 
 ```
-termin_de [options]
-    -b, --before=<date>            Trigger only on date earlier than given date
-    -c, --execute=<command>        Run given command with %{date} and %{link} replacements
-        --dry-run                  Run on saved samples
-        --version                  Display the version
+Usage: termin [options]
+    -b, --before=<date>              Trigger only on date earlier than given date
+    -c, --execute=<command>          Run given command with %{date} and %{link} replacements
+    -s, --service=<id>               Id of the requested service
+        --dry-run                    Run on saved examples
+        --version                    Display the version
 ```
 
 ## Examples
 
 Basically you can sit down, relax, brew some :coffee: and watch at output.
 
-    $ termin_de --before 2015-11-20
-    $ I, [2015-09-21 00:28:47#45699]  INFO -- : Nothing ...
-    $ I, [2015-09-21 00:28:48#46699]  INFO -- : Nothing ...
-    $ I, [2015-09-21 00:28:49#47699]  INFO -- : Found new [2015-11-05] → https://service.berlin.de/terminvereinbarung/termin/termin.php?buergerID=&buergername=&OID=52900%2C54489%2C54574%2C50784%2C54637%2C50792%2C54536%2C54538%2C51456%2C54546%2C54540%2C54542%2C54544%2C54641%2C54033%2C49321%2C49309%2C49334%2C49343%2C54566%2C54568%2C54562%2C54560%2C45160%2C54647%2C54570%2C53880%2C54572%2C53908%2C53907%2C53447%2C53448%2C53433%2C53434%2C53765%2C53766%2C54550%2C54552%2C54554%2C54477%2C54479%2C54481%2C54483%2C54485%2C54524%2C54611%2C54526%2C54614%2C51956%2C54607%2C51627%2C54593%2C54520%2C54495%2C54325%2C54634%2C54601%2C54624%2C52093%2C54230%2C54232%2C54234%2C54206%2C54208%2C54210%2C54212%2C54156%2C54158%2C51543%2C51544%2C51545%2C51521%2C51522%2C51523&datum=2015-11-05&behoerde=&slots=&anliegen%5B%5D=120686&herkunft=%2Fterminvereinbarung%2F
+    $ termin_de --before 2020-09-29
+    $ I, [2020-09-01 20:24:52#30369]  INFO -- : Looking for available slots before 2020-09-29
+    $ I, [2020-09-01 20:24:53#30369]  INFO -- : Nothing ...
+    $ I, [2020-09-01 20:25:53#30369]  INFO -- : Looking for available slots before 2020-09-29
+    $ I, [2020-09-01 20:25:53#30369]  INFO -- : Found new [2020-09-01] → https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1&dienstleisterlist=122243,122238,122260,122262&anliegen[]=120703&herkunft=http%3A%2F%2Fservice.berlin.de%2Fdienstleistung%2F120703%2F
+
+It is also possible to specify the service you are looking for. Maybe you want to perform a business registration.
+
+Be aware that not all offices can process all services.
+
+    $ termin_de --before 2020-09-29 --service 121921
 
 Or you can define your own complex handler and maybe logfile.
 
@@ -48,7 +56,7 @@ Use `--dry-run` option for local sandbox. Sample has 2 available dates `2015-11-
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/setup
+++ b/bin/setup
@@ -2,6 +2,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-bundle install
+bundle install --path vendor/bundle
 
 # Do any other automated setup that you need to do here

--- a/lib/termin_de/calendar.rb
+++ b/lib/termin_de/calendar.rb
@@ -1,10 +1,13 @@
-require "curb"
-require "nokogiri"
+# frozen_string_literal: true
+
+require 'curb'
+require 'nokogiri'
 
 module TerminDe
+  # burgeramt calendar entity
   class Calendar
-    SAMPLES_PATH = File.expand_path("../../../samples/calendar.html", __FILE__)
-    TERMIN_CSS_PATH = "td.buchbar a".freeze
+    SAMPLES_PATH = File.expand_path('../../samples/calendar.html', __dir__)
+    TERMIN_CSS_PATH = 'td.buchbar a'
 
     attr_reader :booked_termin
 
@@ -13,7 +16,7 @@ module TerminDe
       @booked_termin = Termin.new(options.before_date)
     end
 
-    def has_earlier?
+    def earlier?
       !earlier_termin.link.nil? && earlier_termin.date != booked_termin.date
     end
 
@@ -31,8 +34,11 @@ module TerminDe
     end
 
     def download_latest_calendar
-      @options.dry_run? ? Nokogiri.parse(File.read SAMPLES_PATH) :
-                          Nokogiri.parse(Curl::Easy.perform(Termin::QUERY_URL).body_str)
+      if @options.dry_run?
+        Nokogiri.parse(File.read(SAMPLES_PATH))
+      else
+        Nokogiri.parse(Curl::Easy.perform(Termin::QUERY_URL).body_str)
+      end
     end
   end
 end

--- a/lib/termin_de/calendar.rb
+++ b/lib/termin_de/calendar.rb
@@ -7,14 +7,25 @@ require 'time'
 module TerminDe
   # burgeramt calendar entity
   class Calendar
+    BURGERAMT_IDS = [
+      # ALL '122210,122217,327316,122219,327312,122227,122231,327346,122238,122243,327348,122252,329742,122260,329745,122262,329748,122254,329751,122271,327278,122273,122277,327276,122280,327294,122282,327290,122284,327292,122291,327270,122285,327266,122286,327264,122296,327268,327262,325657,150230,329760,122301,327282,122297,327286,122294,327284,122312,329763,122304,327330,122311,327334,122309,327332,317869,324434,122281,327352,122279,122276,327324,122274,327326,122267,329766,122246,327318,122251,327320,327653,122257,327322,122208,122226'
+      '122243', # Friedrichshain Frankfurter
+      '122238', # Friedrichshain Schlesisches Tor
+      '122260', # Lichtenberg Moellendorfstr
+      '122262' # Lichtenberg TierparkCenter
+    ]
     SAMPLES_PATH = File.expand_path('../../samples/calendar.html', __dir__)
     TERMIN_CSS_PATH = 'td.buchbar a'
+    URL = 'https://service.berlin.de/terminvereinbarung/termin'
 
     attr_reader :booked_termin
 
     def initialize(options)
       @options = options
-      @booked_termin = Termin.new(date: options.before_date)
+      @booked_termin = Termin.new(
+        date: options.before_date,
+        service: options.service
+      )
     end
 
     def earlier?
@@ -29,8 +40,21 @@ module TerminDe
       bookable_termins = download_latest_calendar.css(TERMIN_CSS_PATH)
       bookable_termins.map do |link|
         time = Time.at(link.attr(:href).match(/\d+/)[0].to_i)
-        Termin.new(date: Date.parse(time.to_s), link: Termin::QUERY_URL)
+        Termin.new(
+          date: Date.parse(time.to_s),
+          link: url,
+          service: @booked_termin.service
+        )
       end
+    end
+
+    def url
+      [
+        URL + '/tag.php?termin=1',
+        'dienstleisterlist=' + BURGERAMT_IDS.join(','),
+        'anliegen[]=' + @booked_termin.service,
+        'herkunft=http%3A%2F%2Fservice.berlin.de%2Fdienstleistung%2F' + @booked_termin.service + '%2F'
+      ].join('&')
     end
 
     # Downloading the termin calendar
@@ -45,7 +69,7 @@ module TerminDe
       curl = Curl::Easy.new
       curl.enable_cookies = true
       curl.follow_location = true
-      curl.url = Termin::QUERY_URL
+      curl.url = url
       curl.http_get
       Nokogiri.parse(curl.body_str)
     end

--- a/lib/termin_de/cli.rb
+++ b/lib/termin_de/cli.rb
@@ -23,7 +23,7 @@ module TerminDe
 
     Options = Struct.new(:before_date, :dry_run, :command) do
       def command_given?
-        !!command
+        !command.nil?
       end
 
       alias_method :dry_run?, :dry_run

--- a/lib/termin_de/cli.rb
+++ b/lib/termin_de/cli.rb
@@ -8,10 +8,12 @@ module TerminDe
   class Cli
     DEFAULT_DATE = Date.new(3000, 0o1, 0o1)
     DEFAULT_DRY_RUN = false
+    # default request for id card
+    DEFAULT_SERVICE = '120703'
 
     def initialize(argv)
       @argv = argv
-      @options = Options.new(DEFAULT_DATE, DEFAULT_DRY_RUN)
+      @options = Options.new(DEFAULT_DATE, DEFAULT_DRY_RUN, DEFAULT_SERVICE)
     end
 
     def start
@@ -21,7 +23,7 @@ module TerminDe
 
     private
 
-    Options = Struct.new(:before_date, :dry_run, :command) do
+    Options = Struct.new(:before_date, :dry_run, :service, :command) do
       def command_given?
         !command.nil?
       end
@@ -44,6 +46,10 @@ module TerminDe
 
         parser.on('-c', '--execute=<command>', String, 'Run given command with %{date} and %{link} replacements') do |command|
           @options.command = command
+        end
+
+        parser.on('-s', '--service=<id>', String, 'Id of the requested service') do |id|
+          @options.service = !id.nil? ? id : DEFAULT_SERVICE
         end
 
         parser.on('--dry-run', 'Run on saved examples') do

--- a/lib/termin_de/cli.rb
+++ b/lib/termin_de/cli.rb
@@ -1,9 +1,12 @@
-require "optparse"
-require "date"
+# frozen_string_literal: true
+
+require 'optparse'
+require 'date'
 
 module TerminDe
+  # command line interface
   class Cli
-    DEFAULT_DATE = Date.new(3000, 01, 01)
+    DEFAULT_DATE = Date.new(3000, 0o1, 0o1)
     DEFAULT_DRY_RUN = false
 
     def initialize(argv)
@@ -31,15 +34,19 @@ module TerminDe
         parser.banner = "Burgeramt termin monitor\nUsage: termin [options]"
         parser.version = VERSION
 
-        parser.on("-b", "--before=<date>", String, "Trigger only on date earlier than given date") do |date|
-          @options.before_date = Date.parse(date) rescue DEFAULT_DATE
+        parser.on('-b', '--before=<date>', String, 'Trigger only on date earlier than given date') do |date|
+          @options.before_date = begin
+                                   Date.parse(date)
+                                 rescue StandardError
+                                   DEFAULT_DATE
+                                 end
         end
 
-        parser.on("-c", "--execute=<command>", String, "Run given command with %{date} and %{link} replacements") do |command|
+        parser.on('-c', '--execute=<command>', String, 'Run given command with %{date} and %{link} replacements') do |command|
           @options.command = command
         end
 
-        parser.on("--dry-run", "Run on saved examples") do
+        parser.on('--dry-run', 'Run on saved examples') do
           @options.dry_run = true
         end
 

--- a/lib/termin_de/loop.rb
+++ b/lib/termin_de/loop.rb
@@ -6,7 +6,7 @@ module TerminDe
   # Endless loop for querying the burgeramt webpage
   class Loop
     # NOTE : We don't want to be limited by service protection
-    REQUEST_INTERVAL_IN_SECONDS = 120
+    REQUEST_INTERVAL_IN_SECONDS = 60
 
     def initialize(options)
       @options = options
@@ -22,7 +22,7 @@ module TerminDe
         calendar = Calendar.new(@options)
 
         if calendar.earlier?
-          found(calendar)
+          termin_found(calendar.earlier_termin)
         else
           @logger.info 'Nothing ...'
         end
@@ -41,7 +41,7 @@ module TerminDe
         rescue Exception => e
           # NOTE : Arrrgh, Curb doesn't nest exceptions
           raise unless e.class.name =~ /Curl/
-
+          
           @fails += 1
           pause_when(@fails)
         end
@@ -54,8 +54,7 @@ module TerminDe
       sleep(num)
     end
 
-    def termin_found(calendar)
-      termin = calendar.earlier_termin
+    def termin_found(termin)
       @logger.info "Found new [#{termin.date}] → #{termin.link}"
       `#{@options.command % termin.to_h}` if @options.command_given?
     end

--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -1,32 +1,16 @@
 # frozen_string_literal: true
 
-# Anliegen 120703 = ID card
 module TerminDe
-  # simple termin object to hold date and the link
+  # simple termin object to hold date, link and the service
   class Termin
-    
-    URL = 'https://service.berlin.de/terminvereinbarung/termin'
-    ANLIEGEN = '120703'
-    BURGERAMT_IDS = [
-      # ALL '122210,122217,327316,122219,327312,122227,122231,327346,122238,122243,327348,122252,329742,122260,329745,122262,329748,122254,329751,122271,327278,122273,122277,327276,122280,327294,122282,327290,122284,327292,122291,327270,122285,327266,122286,327264,122296,327268,327262,325657,150230,329760,122301,327282,122297,327286,122294,327284,122312,329763,122304,327330,122311,327334,122309,327332,317869,324434,122281,327352,122279,122276,327324,122274,327326,122267,329766,122246,327318,122251,327320,327653,122257,327322,122208,122226'
-      122_243, # Friedrichshain Frankfurter
-      122_238, # Friedrichshain Schlesisches Tor
-      122_260, # Lichtenberg Möllendorfstr
-      122_262, # Lichtenberg TierparkCenter
-    ]
-    QUERY_URL = [
-      'https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1',
-      'dienstleisterlist=' + BURGERAMT_IDS.join(','),
-      'anliegen[]=' + ANLIEGEN,
-      'herkunft=http%3A%2F%2Fservice.berlin.de%2Fdienstleistung%2F' + ANLIEGEN + '%2F'
-    ].join('&')
-
     attr_reader :date
     attr_reader :link
+    attr_reader :service
 
-    def initialize(date:, link: '')
+    def initialize(date:, link: '', service:)
       @date = date
       @link = link
+      @service = service
     end
   end
 end

--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -1,29 +1,32 @@
 # frozen_string_literal: true
 
+# Anliegen 120703 = ID card
 module TerminDe
-  class Termin < Struct.new(:date, :link)
+  # simple termin object to hold date and the link
+  class Termin
+    
     URL = 'https://service.berlin.de/terminvereinbarung/termin'
+    ANLIEGEN = '120703'
     BURGERAMT_IDS = [
-      '&dienstleister%5B%5D=122210&dienstleister%5B%5D=122217&dienstleister%5B%5D=122219',
-      '&dienstleister%5B%5D=122227&dienstleister%5B%5D=122231&dienstleister%5B%5D=122238',
-      '&dienstleister%5B%5D=122243&dienstleister%5B%5D=122252&dienstleister%5B%5D=122260',
-      '&dienstleister%5B%5D=122262&dienstleister%5B%5D=122254&dienstleister%5B%5D=122271',
-      '&dienstleister%5B%5D=122273&dienstleister%5B%5D=122277&dienstleister%5B%5D=122280',
-      '&dienstleister%5B%5D=122282&dienstleister%5B%5D=122284&dienstleister%5B%5D=122291',
-      '&dienstleister%5B%5D=122285&dienstleister%5B%5D=122286&dienstleister%5B%5D=122296',
-      '&dienstleister%5B%5D=150230&dienstleister%5B%5D=122301&dienstleister%5B%5D=122297',
-      '&dienstleister%5B%5D=122294&dienstleister%5B%5D=122312&dienstleister%5B%5D=122314',
-      '&dienstleister%5B%5D=122304&dienstleister%5B%5D=122311&dienstleister%5B%5D=122309',
-      '&dienstleister%5B%5D=317869&dienstleister%5B%5D=324433&dienstleister%5B%5D=325341',
-      '&dienstleister%5B%5D=324434&dienstleister%5B%5D=324435&dienstleister%5B%5D=122281',
-      '&dienstleister%5B%5D=324414&dienstleister%5B%5D=122283&dienstleister%5B%5D=122279',
-      '&dienstleister%5B%5D=122276&dienstleister%5B%5D=122274&dienstleister%5B%5D=122267',
-      '&dienstleister%5B%5D=122246&dienstleister%5B%5D=122251&dienstleister%5B%5D=122257',
-      '&dienstleister%5B%5D=122208&dienstleister%5B%5D=122226'
-    ].join
+      # ALL '122210,122217,327316,122219,327312,122227,122231,327346,122238,122243,327348,122252,329742,122260,329745,122262,329748,122254,329751,122271,327278,122273,122277,327276,122280,327294,122282,327290,122284,327292,122291,327270,122285,327266,122286,327264,122296,327268,327262,325657,150230,329760,122301,327282,122297,327286,122294,327284,122312,329763,122304,327330,122311,327334,122309,327332,317869,324434,122281,327352,122279,122276,327324,122274,327326,122267,329766,122246,327318,122251,327320,327653,122257,327322,122208,122226'
+      122_243, # Friedrichshain Frankfurter
+      122_238, # Friedrichshain Schlesisches Tor
+      122_260, # Lichtenberg Möllendorfstr
+      122_262, # Lichtenberg TierparkCenter
+    ]
     QUERY_URL = [
       'https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1',
-      BURGERAMT_IDS, '&anliegen%5B%5D=120686&herkunft=%2Fterminvereinbarung%2F'
-    ].join
+      'dienstleisterlist=' + BURGERAMT_IDS.join(','),
+      'anliegen[]=' + ANLIEGEN,
+      'herkunft=http%3A%2F%2Fservice.berlin.de%2Fdienstleistung%2F' + ANLIEGEN + '%2F'
+    ].join('&')
+
+    attr_reader :date
+    attr_reader :link
+
+    def initialize(date:, link: '')
+      @date = date
+      @link = link
+    end
   end
 end

--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 module TerminDe
   class Termin < Struct.new(:date, :link)
-    URL = "https://service.berlin.de/terminvereinbarung/termin".freeze
+    URL = 'https://service.berlin.de/terminvereinbarung/termin'
     BURGERAMT_IDS = [
-      "&dienstleister%5B%5D=122210&dienstleister%5B%5D=122217&dienstleister%5B%5D=122219",
-      "&dienstleister%5B%5D=122227&dienstleister%5B%5D=122231&dienstleister%5B%5D=122238",
-      "&dienstleister%5B%5D=122243&dienstleister%5B%5D=122252&dienstleister%5B%5D=122260",
-      "&dienstleister%5B%5D=122262&dienstleister%5B%5D=122254&dienstleister%5B%5D=122271",
-      "&dienstleister%5B%5D=122273&dienstleister%5B%5D=122277&dienstleister%5B%5D=122280",
-      "&dienstleister%5B%5D=122282&dienstleister%5B%5D=122284&dienstleister%5B%5D=122291",
-      "&dienstleister%5B%5D=122285&dienstleister%5B%5D=122286&dienstleister%5B%5D=122296",
-      "&dienstleister%5B%5D=150230&dienstleister%5B%5D=122301&dienstleister%5B%5D=122297",
-      "&dienstleister%5B%5D=122294&dienstleister%5B%5D=122312&dienstleister%5B%5D=122314",
-      "&dienstleister%5B%5D=122304&dienstleister%5B%5D=122311&dienstleister%5B%5D=122309",
-      "&dienstleister%5B%5D=317869&dienstleister%5B%5D=324433&dienstleister%5B%5D=325341",
-      "&dienstleister%5B%5D=324434&dienstleister%5B%5D=324435&dienstleister%5B%5D=122281",
-      "&dienstleister%5B%5D=324414&dienstleister%5B%5D=122283&dienstleister%5B%5D=122279",
-      "&dienstleister%5B%5D=122276&dienstleister%5B%5D=122274&dienstleister%5B%5D=122267",
-      "&dienstleister%5B%5D=122246&dienstleister%5B%5D=122251&dienstleister%5B%5D=122257",
-      "&dienstleister%5B%5D=122208&dienstleister%5B%5D=122226",
+      '&dienstleister%5B%5D=122210&dienstleister%5B%5D=122217&dienstleister%5B%5D=122219',
+      '&dienstleister%5B%5D=122227&dienstleister%5B%5D=122231&dienstleister%5B%5D=122238',
+      '&dienstleister%5B%5D=122243&dienstleister%5B%5D=122252&dienstleister%5B%5D=122260',
+      '&dienstleister%5B%5D=122262&dienstleister%5B%5D=122254&dienstleister%5B%5D=122271',
+      '&dienstleister%5B%5D=122273&dienstleister%5B%5D=122277&dienstleister%5B%5D=122280',
+      '&dienstleister%5B%5D=122282&dienstleister%5B%5D=122284&dienstleister%5B%5D=122291',
+      '&dienstleister%5B%5D=122285&dienstleister%5B%5D=122286&dienstleister%5B%5D=122296',
+      '&dienstleister%5B%5D=150230&dienstleister%5B%5D=122301&dienstleister%5B%5D=122297',
+      '&dienstleister%5B%5D=122294&dienstleister%5B%5D=122312&dienstleister%5B%5D=122314',
+      '&dienstleister%5B%5D=122304&dienstleister%5B%5D=122311&dienstleister%5B%5D=122309',
+      '&dienstleister%5B%5D=317869&dienstleister%5B%5D=324433&dienstleister%5B%5D=325341',
+      '&dienstleister%5B%5D=324434&dienstleister%5B%5D=324435&dienstleister%5B%5D=122281',
+      '&dienstleister%5B%5D=324414&dienstleister%5B%5D=122283&dienstleister%5B%5D=122279',
+      '&dienstleister%5B%5D=122276&dienstleister%5B%5D=122274&dienstleister%5B%5D=122267',
+      '&dienstleister%5B%5D=122246&dienstleister%5B%5D=122251&dienstleister%5B%5D=122257',
+      '&dienstleister%5B%5D=122208&dienstleister%5B%5D=122226'
     ].join
     QUERY_URL = [
-      "https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1",
-      BURGERAMT_IDS, "&anliegen%5B%5D=120686&herkunft=%2Fterminvereinbarung%2F"
+      'https://service.berlin.de/terminvereinbarung/termin/tag.php?termin=1',
+      BURGERAMT_IDS, '&anliegen%5B%5D=120686&herkunft=%2Fterminvereinbarung%2F'
     ].join
   end
 end

--- a/lib/termin_de/version.rb
+++ b/lib/termin_de/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TerminDe
-  VERSION = "0.0.1"
+  VERSION = '0.1.0'
 end

--- a/samples/calendar.html
+++ b/samples/calendar.html
@@ -1,709 +1,1010 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de" dir="ltr">
+<!doctype html>
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
+
 <head>
+    <title>Terminvergabe - Auswahl des Tages - Service Berlin - Berlin.de</title>
+    <meta name="robots" content="NOINDEX NOFOLLOW">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <link rel="alternate" hreflang="en" href="/terminvereinbarung/termin/day/" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/vendor.css?ts=1598457878" />
 
-<meta http-equiv="expires" content="0" />
-<meta http-equiv="cache-control" content="no-cache" />
-<meta http-equiv="pragma" content="no-cache" />
-<meta name="robots" content="noindex, nofollow" /> 
-
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/vendor.css?ts=1441880898"/>
-<!-- theme switch begin -->
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/bde-bootstrap.css?ts=1441880898"/>
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/bde-index.css?ts=1441880898"/>
-    <link rel="shortcut icon" href="//service.berlin.de/i9f/images/favicon.ico" type="image/x-icon"/>
-    <link rel="apple-touch-icon" href="//service.berlin.de/i9f/images/iphone.png" type="image/png"/>
-<!-- theme switch end -->
-<!--[if IE 7]>
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/berlin_ie7.css?ts=1441880898" />
-<![endif]-->
-<!--[if IE 8]>
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/berlin_ie8.css?ts=1441880898" />
-<![endif]-->
-<!--[if IE 9]>
-    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/berlin_ie9.css?ts=1441880898" />
-<![endif]-->
+    <!-- theme switch begin -->
+    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/bde-bootstrap.css?ts=1598457878" />
+    <link rel="stylesheet" type="text/css" href="//service.berlin.de/i9f/v4/css/bde-index.css?ts=1598457878" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="apple-touch-icon" sizes="180x180" href="//service.berlin.de/i9f/v4/css/images/misc/apple-touch-icon.png" type="image/png" />
+    <!-- theme switch end -->
 
     <!-- "property" validiert nicht, nimm "name" -->
-    <meta name="og:image" content="http://service.berlin.de/i9f/images/facebook_default_icon_land.png"/>
-    <meta name="og:image:secure_url" content="https://service.berlin.de/i9f/images/facebook_default_icon_land.png"/>
-    <script type="text/javascript" src="//service.berlin.de/i9f/v4/js/bo-head.js?ts=1441880898"></script>
+    <meta name="og:image" content="http://service.berlin.de/i9f/images/facebook_default_icon_land.png" />
+    <meta name="og:image:secure_url" content="https://service.berlin.de/i9f/images/facebook_default_icon_land.png" />
+    <script src="//service.berlin.de/i9f/v4/js/bo-head.js?ts=1598457878"></script>
+    <script src="//service.berlin.de/i9f/v4/js/bo-info.js?ts=1598457878"></script>
 
 
-<!--
-  layout: std
-  created on: Thu, 10 Sep 2015 17:03:33 +0200
+    <!--
+  layout: ohne
+  url: /service.berlin.de/terminvereinbarung/__i9/ohne/head.inc  created on: Sun, 30 Aug 2020 22:41:25 +0200
 -->
 
 
-
-
-<!--<link rel="stylesheet" type="text/css" href="styles/i9f/stage/berlin.css" />-->
-<title>Terminvergabe - Auswahl des Tages</title>
+    <link rel="stylesheet" type="text/css" href="/terminvereinbarung/termin/_css/appointment.css">
+    <link rel="canonical" href="http://service.berlin.de/">
 </head>
-<body>
 
 
-                <div class="container-wrapper container-portal-header">
-            <div class="container">
-                <div class="row">
-                    <div class="span12">
-                                                    
-                <!-- NAVIGATION BEGIN: portal -->
+<body class="locale_de" id="dayselect">
 
-                <div class="html5-header portal-header hidden-phone">
-                    <div class="red-line"></div>
-                    <div class="html5-figure main-image">
-                        <a href="http://www.berlin.de/">
-                            <img class="portal-logo hide-mobile" src="//service.berlin.de/i9f/images/berlin_de.png" alt="Zur Homepage von Berlin.de" />
-                        </a>
-                    </div><!-- /html5-figure -->
 
-                    <p class="navSkip">Navigiere direkt zu:</p>
-                    <ul class="navSkip">
-                        <li><a href="#aural_institutionssuche">Suche</a></li>
-                        <li><a href="#aural_maincontent">Inhalt</a></li>
-                    </ul>
+    <div class="container-wrapper container-portal-header">
+        <!-- Werbung -->
+        <div class="skyscraper hidden-phone">
+            <!-- kommunal: beberlin -->
+        </div>
+        <div class="container">
+            <div class="row">
+                <div class="span12">
 
-                    <div class="html5-nav" role="navigation" aria-label="Globale Portal-Links">
-                        <p class="aural" id="bo-portalnavilinkslabel">Besuchen Sie auch unsere anderen Themen-Bereiche:</p>
-                        <ul class="portal-navi" id="bo-portalnavilinks" aria-labelledby="bo-portalnavilinkslabel">
-                            <li class="active"><a href="http://www.berlin.de/rubrik/politik-und-verwaltung/">Politik, Verwaltung, Bürger</a></li>
-                            <li><a href="http://www.berlin.de/kultur-und-tickets/">Kultur &#38; Ausgehen</a></li>
-                            <li><a href="http://www.berlin.de/tourismus/">Tourismus</a></li>
-                            <li><a href="http://www.berlin.de/wirtschaft/">Wirtschaft</a></li>
-                            <li><a href="http://www.berlin.de/special/">Themen</a></li>
-                            <li><a href="http://www.berlin.de/adressen/">BerlinFinder</a></li>
-                            <li><a href="http://www.berlin.de/stadtplan/">Stadtplan</a></li>
+                    <!-- NAVIGATION BEGIN: portal -->
+
+                    <div class="html5-header portal-header hidden-phone">
+                        <div class="red-line"></div>
+                        <div class="html5-figure main-image">
+                            <a href="https://www.berlin.de/">
+                                <img class="portal-logo hide-mobile" src="//service.berlin.de/i9f/v4/css/images/berlin_de.png" alt="Zur Homepage von Berlin.de" />
+                            </a>
+                        </div>
+                        <!-- /html5-figure -->
+
+                        <p class="navSkip hidden-phone osvnp">Navigiere direkt zu:</p>
+                        <ul class="navSkip hidden-phone">
+                            <li><a href="#aural_institutionssuche">Suche</a></li>
+                            <li><a href="#aural_maincontent">Inhalt</a></li>
                         </ul>
-                    </div><!-- /html5-nav -->
-                </div><!-- /html5-header -->
-                <!-- NAVIGATION END: portal -->
-                                            </div>
+
+                        <nav aria-label="Portal Navigation">
+                            <h6 class="aural">Portal Navigation</h6>
+                            <p class="aural" id="bo-portalnavilinkslabel">Besuchen Sie auch unsere anderen Themen-Bereiche:
+                            </p>
+                            <ul class="portal-navi" id="bo-portalnavilinks" aria-labelledby="bo-portalnavilinkslabel">
+                                <li class="active"><a href="https://www.berlin.de/politik-verwaltung-buerger/">Politik,
+                                        Verwaltung, B&#252;rger</a></li>
+                                <li><a href="https://www.berlin.de/kultur-und-tickets/">Kultur &#38; Ausgehen</a></li>
+                                <li><a href="https://www.berlin.de/tourismus/">Tourismus</a></li>
+                                <li><a href="https://www.berlin.de/wirtschaft/">Wirtschaft</a></li>
+                                <li><a href="https://www.berlin.de/special/">Lifestyle</a></li>
+                                <li><a href="https://www.berlin.de/adressen/">BerlinFinder</a></li>
+                                <li><a href="https://www.berlin.de/stadtplan/">Stadtplan</a></li>
+                            </ul>
+                        </nav>
+                        <!-- /html5-nav -->
+                    </div>
+                    <!-- /html5-header -->
+                    <!-- NAVIGATION END: portal -->
                 </div>
             </div>
         </div>
-        
-                <div id="top" class="container-wrapper container-content template-land_overview">
-            <div class="container">
-                <div class="row">
-                    <div class="span12">
+    </div>
 
-                                                <!-- NAVIGATION BEGIN: horizontal-->
-<div class="row">
-    <div class="span12">
-<!--NAVIGATION BEGIN: meta-->
-<div class="html5-header content-header ">
-    <div class="row">
-        <div class="span5">
-            <div class="html5-section section-logo without-logo">
-                                <div class="html5-section text">
-                    <a href="https://service.berlin.de/" title="Link zu: Startseite von Service-Portal Berlin"><span class="institution">Service-Portal</span>
-            <span class="title">Berlin</span></a>                </div>
-            </div>
+    <!-- navi mobil header inc -->
+    <div class="sticky-header hidden-desktop hidden-tablet bde-gradient">
+        <div class="red-line"></div>
+        <div class="portal-logo">
+            <a title="Link f&#252;hrt zur Startseite von Berlin.de" href="https://www.berlin.de">
+                <img title="Link f&#252;hrt zur Startseite von Berlin.de" alt="Bild zeigt: Berlin.de Logo" src="//service.berlin.de/i9f/v4/css/images/berlin_de.png" />
+            </a>
         </div>
+    </div>
+    <!-- navi mobil header inc -->
 
-        <div class="span7">
-                            <div class="html5-nav meta-navi">
-                    <ul class="nav">
+
+    <div id="top" class="container-wrapper container-content template-land_overview">
+        <div class="container">
+            <div class="row">
+                <div class="span12">
+                    <!-- NAVIGATION BEGIN: horizontal-->
+                    <div class="row">
+                        <div class="span12">
+                            <!--NAVIGATION BEGIN: meta-->
+                            <div class="html5-header content-header ">
+                                <div class="row">
+                                    <div class="span5">
+                                        <div class="html5-section section-logo
+ without-logo">
+                                            <div class="html5-section text">
+                                                <a href="https://service.berlin.de/" title="Link zu: Startseite von &#34;Service-Portal Berlin&#34;"><span
+                                                        class="institution">Service-Portal</span>
+                                                    <span class="title">Berlin</span></a> </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="span7">
+                                        <div class="html5-nav meta-navi">
+                                            <ul class="nav">
                                             </ul>
-                </div>
+                                        </div>
                                         <!--META BEGIN: SEARCH-->
-                <div class="html5-section search navbar">
-                    <div class="navbar-inner">
-                        <div class="nav-collapse search-collapse collapse">
-                            <form class="institutionssuche" method="get" action="https://service.berlin.de/suche/stichwort/">
-    <div class="control-group searchform " role="search">
-        <p class="aural" id="aural_institutionssuche">
-            Suche auf der Internetseite 'Service-Portal Berlin':        </p>
-        <input type="search" placeholder="Suchbegriff"
-            name="x" aria-labelledby="aural_institutionssuche"
-            maxlength="255"
-            title="Hier können Sie einen Text eingeben, um die Internetseite 'Service-Portal Berlin' zu durchsuchen"
-        />
-        <button class="btn global-search-submit" type="submit">
-            <i class="icon-search icon-white"></i>
-            <span class="hidden-phone">Suchen</span>
-        </button>
-    </div>
-</form>
+                                        <div class="html5-section search navbar">
+                                            <div class="navbar-inner">
+                                                <div class="nav-collapse search-collapse collapse">
+                                                    <form class="institutionssuche" method="get" action="https://service.berlin.de/suche/stichwort/">
+                                                        <div class="control-group searchform " role="search">
+                                                            <label class="aural" id="aural_institutionssuche">
+                                                                Suche auf der Internetseite &#34;Service-Portal
+                                                                Berlin&#34;: </label>
+                                                            <input type="search" placeholder="Suchbegriff" name="x" aria-labelledby="aural_institutionssuche" maxlength="255" title="Hier k&#246;nnen Sie einen Text eingeben, um die Internetseite &#34;Service-Portal Berlin&#34; zu durchsuchen" />
+                                                            <button class="btn global-search-submit" type="submit">
+                                                                <span class="hidden-phone">Suchen</span>
+                                                            </button>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <!--META END: SEARCH-->
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- NAVIGATION END: meta-->
                         </div>
                     </div>
-                </div>
-                <!--META END: SEARCH-->
-                    </div>
-    </div>
-</div>
-<!-- NAVIGATION END: meta-->
-    </div>
-</div>
-<div class="row">
-    <div class="span12">
-        <span class="mobile-blue-line hidden-desktop hidden-tablet"></span>
-        <div class="content-navi-wrapper navbar hidden-phone">
-            <div class="html5-nav content-navi-top navbar-inner">
-                <div class="nav-collapse mainnav-collapse collapse" style="height: 0px">
-                    <p class="aural">Hauptnavigation</p>
-                    <ul class="nav level1"  >
-                                <li class=" has-submenu">
-            <a href="https://service.berlin.de/themen/" >Themen</a>                    </li>
-        <li class=" has-submenu">
-            <a href="https://service.berlin.de/dienstleistungen/" >Dienst&shy;leistungen</a>                    </li>
-        <li class=" has-submenu">
-            <a href="https://service.berlin.de/standorte/" >Standorte</a>            <ul class="nav">        <li class="">
-            <a href="https://service.berlin.de/standorte/" >Standorte A-Z</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/behoerden/" >Behörden A-Z</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/serviceatlas/" >Serviceatlas</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/auslandsamt/" >Ausländer&shy;behörde</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/buergeraemter/" >Bürgerämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/finanzaemter/" >Finanzämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/gesundheitsaemter/" >Gesundheits&shy;ämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/kfz-zulassungsstellen/" >KFZ-Zulassungs&shy;stellen</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/jugendaemter/" >Jugendämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/ordnungsaemter/" >Ordnungsämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/sozialaemter/" >Sozialämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/standesaemter/" >Standesämter</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/standorte/weitere/" >Weitere Standorte</a>                    </li>
-</ul>        </li>
-        <li class=" active has-submenu">
-            <a href="https://service.berlin.de/terminvereinbarung/" >Termin&shy;vereinbarung</a>            <ul class="nav">        <li class="">
-            <a href="https://service.berlin.de/terminvereinbarung/hinweise/" >Hinweise</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php" >Termin ändern</a>                    </li>
-        <li class="">
-            <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/" >Datenschutz&shy;erklärung</a>                    </li>
-</ul>        </li>
-        <li class=" has-submenu">
-            <a href="https://service.berlin.de/onlineverfahren-onlinedienstleistungen/" >Online-Verfahren</a>                    </li>
-        <li class=" has-submenu">
-            <a href="https://service.berlin.de/app/" >App</a>                    </li>
-                                            </ul>
-                                        <div class="beberlin"><img alt="Logo beBerlin" title="Logo beBerlin" src="//service.berlin.de/i9f/v4/css/images/logo_beberlin_darkblue.png" /></div>
-                                    </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!--NAVIGATION END: horizontal-->
-
-<!-- content start -->
-<!-- row - span12 -->
-
-
-                        <!-- NAVIGATION BEGIN: breadcrumb -->
-<div class="row row-breadcrumb">
-  <div class="span10">
-
-    <div class="html5-section breadcrumb" role="navigation" aria-label="Breadcrumb">
-      <p id="aural_breadcrumblabel" class="aural">Sie befinden sich hier:</p>
-      <ul aria-labelledby="aural_breadcrumblabel">
-        <li class="odd pos0"><a href="https://service.berlin.de/" class="homehaus">service.berlin.de</a></li><li class="even pos1"><a href="https://service.berlin.de/terminvereinbarung/" >Termin&shy;vereinbarung</a></li>        <li class="aural">Terminvereinbarung bei Berliner Behörden</li>
-      </ul>
-    </div>
-  </div>
-  <div class="span2"></div>
-</div>
-<!-- NAVIGATION END: breadcrumb -->
-
-<div class="row">
-    <div class="span2 column-left">
-        <!-- NAVIGATION BEGIN: vertical -->
-<div class="html5-nav content-navigation-left navbar">
-    <div class="navbar-inner">
-        <div class="hidden-phone nav-collapse collapse ">
-            <p class="aural">Sekundäre Navigation</p>
-            <ul class="nav level-0">
-                <li class="active"><a href="https://service.berlin.de/terminvereinbarung/" >Termin&shy;vereinbarung</a>                    <ul class="level-1" ><li >
-    <a href="https://service.berlin.de/terminvereinbarung/hinweise/" >Hinweise</a>    </li>
-<li >
-    <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php" >Termin ändern</a>    </li>
-<li >
-    <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/" >Datenschutz&shy;erklärung</a>    </li>
-</ul>                </li>
-            </ul>
-        </div>
-    </div>
-</div>
-<!-- NAVIGATION END: vertical -->
-    </div>
-
-    <div class="span7 column-content">
-        <p class="aural"><a id="aural_maincontent" title="Inhaltsspalte"></a></p>
-        <div class="html5-section article" role="main">
-
-<!--anker:allris-->
-
-
-    
-<div id="hhibody" class="zms"> <!-- HHI BODY Begin: all HHI contents ////////////////////////////////////////////////////// -->
-
-<!-- BREADCRUMB Begin  ////////////////////////////////////////////////////// -->
-<!-- BREADCRUMB End  ////////////////////////////////////////////////////// -->
-
-
-<!-- OPENER Begin -->
-    <div class="html5-header header">
-    <h1 class="title">Terminvereinbarung
-    </h1>
-    </div>
-<!-- OPENER End  -->
-
-<!-- MERKZETTEL Begin  ////////////////////////////////////////////////////// -->
-    <!-- MERKZETTEL Begin  ////////////////////////////////////////////////////// -->
-            <div class="collapsible-group closed">
-                <div class="collapsible-heading row-fluid">
-                    <div class="collapsible-toggle">
-                        <div class="table-cell collapsible-counter span1">
-                            1                        </div>
-                        <div class="table-cell collapsible-title span3">
-                            Dienst&shy;leis&shy;tung                        </div>
-                        <div class="table-cell collapsible-description span7">
-                            <div class="bullet"> Anmeldung einer Wohnung </div>                        </div>
-                        <div class="table-cell collapsible-options span1">
-                            <a class="edit icon-pencil" href="https://service.berlin.de/dienstleistungen/?zms=1" accesskey="1" title="Zur Dienstleistungsauswahl" tabindex="13">&auml;ndern</a>
+                    <div class="row">
+                        <div class="span12">
+                            <span class="mobile-blue-line hidden-desktop hidden-tablet"></span>
+                            <div class="content-navi-wrapper navbar hidden-phone">
+                                <div class="html5-nav content-navi-top navbar-inner
+">
+                                    <nav class="nav-collapse mainnav-collapse collapse" aria-label="Hauptnavigation">
+                                        <h6 class="aural">Hauptnavigation</h6>
+                                        <ul class="nav level1">
+                                            <li class=" has-submenu">
+                                                <a href="https://service.berlin.de/dienstleistungen/">Dienst&#173;leistungen</a>
+                                            </li>
+                                            <li class=" has-submenu">
+                                                <a href="https://service.berlin.de/standorte/">Standorte</a>
+                                                <ul class="nav">
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/">Standorte A-Z</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/behoerden/">Beh&#246;rden
+                                                            A-Z</a> </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/serviceatlas/">Serviceatlas</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/buergeraemter/">B&#252;rger&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/einwanderungsamt/">Einwanderungs&#173;amt</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/finanzaemter/">Finanz&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/gesundheitsaemter/">Gesundheits&#173;&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/jugendaemter/">Jugend&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/kfz-zulassungsstellen/">KFZ-Zulassungs&#173;stellen</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/ordnungsaemter/">Ordnungs&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/sozialaemter/">Sozial&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/standesaemter/">Standes&#228;mter</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/standorte/weitere/">Weitere
+                                                            Standorte</a> </li>
+                                                </ul>
+                                            </li>
+                                            <li class=" active has-submenu">
+                                                <a href="https://service.berlin.de/terminvereinbarung/">Termin&#173;vereinbarung</a>
+                                                <ul class="nav">
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/terminvereinbarung/hinweise/">Hinweise</a>
+                                                    </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php">Termin
+                                                            &#228;ndern</a> </li>
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/">Datenschutz&#173;erkl&#228;rung</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class=" has-submenu">
+                                                <a href="https://service.berlin.de/onlineverfahren-onlinedienstleistungen/">Online-Verfahren</a>
+                                            </li>
+                                            <li class=" has-submenu">
+                                                <a href="https://service.berlin.de/app/">App</a>
+                                                <ul class="nav">
+                                                    <li class="">
+                                                        <a href="https://service.berlin.de/app/datenschutzerklaerung/">Daten&#173;schutz&#173;erkl&#228;rung</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class=" has-submenu">
+                                                <a href="https://service.berlin.de/themen/">Themen</a> </li>
+                                        </ul>
+                                        <div class="beberlin"><img alt="Logo beBerlin" title="beBerlin" src="//service.berlin.de/i9f/v4/css/images/logo_beberlin_darkblue.png" />
+                                        </div>
+                                    </nav>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </div>
-
-    <!-- MERKZETTEL End  ////////////////////////////////////////////////////// -->
-<!-- MERKZETTEL End  -->
-
-
-<!-- TASK Begin  ////////////////////////////////////////////////////// -->
-<div class="collapsible-group">
-        
-    <div class="collapsible-heading row-fluid">
-        <div class="collapsible-toggle">
-            <span class="table-cell collapsible-counter span1">2</span>
-            <span class="table-cell collapsible-title span11">Datum</span>
-        </div>
-    </div>
-
-    <div class="collapsible-body">
-
-                <div class="calendar-table">
-                
-                <div class="calendar-head">
-                    <h2 class="title">Bitte w&auml;hlen Sie ein Datum:</h2>
-                    <div class="calendar-legend right">
-                        <span class="legend-element"><span class="legend-color buchbar">&nbsp;</span>verf&uuml;gbar</span>
-                        <span class="legend-element"><span class="legend-color nichtbuchbar">&nbsp;</span>ausgebucht</span>
+                    <div class="emergency-box">
+                        <div class="textile">&#10;
+                            <p>&#10; In den Vormittagsstunden ist der eMail-Versand aus dem Terminbuchungssystem etwas verz&#246;gert.&#10; </p>&#10;</div>
                     </div>
-                </div>
-                <div class="row-fluid">
-          
-                        <div class="calendar-month-table span6">
-                            <table cellspacing="0">
-                                <thead>
-                                    <tr class="controll">
-                                        <th class="prev">
-                                        <a title="voriger Monat" href="tag.php?id=&amp;buergerID&amp;buergername=&amp;absagecode=&amp;Datum=1441058400&amp;anliegen%5B%5D=120686&amp;dienstleister%5B%5D=122210&amp;dienstleister%5B%5D=122217&amp;dienstleister%5B%5D=122219&amp;dienstleister%5B%5D=122227&amp;dienstleister%5B%5D=122231&amp;dienstleister%5B%5D=122238&amp;dienstleister%5B%5D=122243&amp;dienstleister%5B%5D=122252&amp;dienstleister%5B%5D=122260&amp;dienstleister%5B%5D=122262&amp;dienstleister%5B%5D=122254&amp;dienstleister%5B%5D=122271&amp;dienstleister%5B%5D=122273&amp;dienstleister%5B%5D=122277&amp;dienstleister%5B%5D=122280&amp;dienstleister%5B%5D=122282&amp;dienstleister%5B%5D=122284&amp;dienstleister%5B%5D=122291&amp;dienstleister%5B%5D=122285&amp;dienstleister%5B%5D=122286&amp;dienstleister%5B%5D=122296&amp;dienstleister%5B%5D=150230&amp;dienstleister%5B%5D=122301&amp;dienstleister%5B%5D=122297&amp;dienstleister%5B%5D=122294&amp;dienstleister%5B%5D=122312&amp;dienstleister%5B%5D=122314&amp;dienstleister%5B%5D=122304&amp;dienstleister%5B%5D=122311&amp;dienstleister%5B%5D=122309&amp;dienstleister%5B%5D=317869&amp;dienstleister%5B%5D=324433&amp;dienstleister%5B%5D=325341&amp;dienstleister%5B%5D=324434&amp;dienstleister%5B%5D=324435&amp;dienstleister%5B%5D=122281&amp;dienstleister%5B%5D=324414&amp;dienstleister%5B%5D=122283&amp;dienstleister%5B%5D=122279&amp;dienstleister%5B%5D=122276&amp;dienstleister%5B%5D=122274&amp;dienstleister%5B%5D=122267&amp;dienstleister%5B%5D=122246&amp;dienstleister%5B%5D=122251&amp;dienstleister%5B%5D=122257&amp;dienstleister%5B%5D=122208&amp;dienstleister%5B%5D=122226&amp;herkunft=/terminvereinbarung/">«</a>                                        </th>
-                                        <th class="month" colspan="5">
-                                            Oktober 2015                                        </th>
-                                        <th class="next">
-                                            <a title="n&auml;chster Monat" href="tag.php?id=&amp;buergerID=&amp;buergername=&amp;absagecode=&amp;Datum=1443650400&amp;anliegen%5B%5D=120686&amp;dienstleister%5B%5D=122210&amp;dienstleister%5B%5D=122217&amp;dienstleister%5B%5D=122219&amp;dienstleister%5B%5D=122227&amp;dienstleister%5B%5D=122231&amp;dienstleister%5B%5D=122238&amp;dienstleister%5B%5D=122243&amp;dienstleister%5B%5D=122252&amp;dienstleister%5B%5D=122260&amp;dienstleister%5B%5D=122262&amp;dienstleister%5B%5D=122254&amp;dienstleister%5B%5D=122271&amp;dienstleister%5B%5D=122273&amp;dienstleister%5B%5D=122277&amp;dienstleister%5B%5D=122280&amp;dienstleister%5B%5D=122282&amp;dienstleister%5B%5D=122284&amp;dienstleister%5B%5D=122291&amp;dienstleister%5B%5D=122285&amp;dienstleister%5B%5D=122286&amp;dienstleister%5B%5D=122296&amp;dienstleister%5B%5D=150230&amp;dienstleister%5B%5D=122301&amp;dienstleister%5B%5D=122297&amp;dienstleister%5B%5D=122294&amp;dienstleister%5B%5D=122312&amp;dienstleister%5B%5D=122314&amp;dienstleister%5B%5D=122304&amp;dienstleister%5B%5D=122311&amp;dienstleister%5B%5D=122309&amp;dienstleister%5B%5D=317869&amp;dienstleister%5B%5D=324433&amp;dienstleister%5B%5D=325341&amp;dienstleister%5B%5D=324434&amp;dienstleister%5B%5D=324435&amp;dienstleister%5B%5D=122281&amp;dienstleister%5B%5D=324414&amp;dienstleister%5B%5D=122283&amp;dienstleister%5B%5D=122279&amp;dienstleister%5B%5D=122276&amp;dienstleister%5B%5D=122274&amp;dienstleister%5B%5D=122267&amp;dienstleister%5B%5D=122246&amp;dienstleister%5B%5D=122251&amp;dienstleister%5B%5D=122257&amp;dienstleister%5B%5D=122208&amp;dienstleister%5B%5D=122226&amp;herkunft=/terminvereinbarung/">»</a>                                        </th>
-                                    </tr>
-                                    <tr class="dayname">
-                                        <th>Mo</th>
-                                        <th>Di</th>
-                                        <th>Mi</th>
-                                        <th>Do</th>
-                                        <th>Fr</th>
-                                        <th>Sa</th>
-                                        <th><span class="sonnfeiertag">So</span></th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td class="nichtbuchbar "><span>1</span></td>
-<td class="nichtbuchbar "><span>2</span></td>
-<td><span class="sonnfeiertag"><span>3</span></span></td>
-<td><span class="sonnfeiertag"><span>4</span></span></td>
-</tr><tr>
-<td class="nichtbuchbar "><span>5</span></td>
-<td class="nichtbuchbar "><span>6</span></td>
-<td class="nichtbuchbar "><span>7</span></td>
-<td class="nichtbuchbar "><span>8</span></td>
-<td class="nichtbuchbar "><span>9</span></td>
-<td class="nichtbuchbar "><span>10</span></td>
-<td><span class="sonnfeiertag"><span>11</span></span></td>
-</tr><tr>
-<td class="nichtbuchbar "><span>12</span></td>
-<td class="nichtbuchbar "><span>13</span></td>
-<td class="nichtbuchbar "><span>14</span></td>
-<td class="nichtbuchbar "><span>15</span></td>
-<td class="nichtbuchbar "><span>16</span></td>
-<td class="nichtbuchbar "><span>17</span></td>
-<td><span class="sonnfeiertag"><span>18</span></span></td>
-</tr><tr>
-<td class="nichtbuchbar "><span>19</span></td>
-<td class="nichtbuchbar "><span>20</span></td>
-<td class="nichtbuchbar "><span>21</span></td>
-<td class="nichtbuchbar "><span>22</span></td>
-<td class="nichtbuchbar "><span>23</span></td>
-<td class="nichtbuchbar "><span>24</span></td>
-<td><span class="sonnfeiertag"><span>25</span></span></td>
-</tr><tr>
-<td class="nichtbuchbar "><span>26</span></td>
-<td class="nichtbuchbar "><span>27</span></td>
-<td class="nichtbuchbar "><span>28</span></td>
-<td class="nichtbuchbar "><span>29</span></td>
-<td class="nichtbuchbar "><span>30</span></td>
-<td class="nichtbuchbar "><span>31</span></td>
-<td>&nbsp;</td>
-</tr>
-                                </tbody>
-                            </table>
-                        </div> <!-- /calendar-month-table END -->
-          
-                        <div class="calendar-month-table span6">
-                            <table cellspacing="0">
-                                <thead>
-                                    <tr class="controll">
-                                        <th class="prev">
-                                                                                </th>
-                                        <th class="month" colspan="5">
-                                            November 2015                                        </th>
-                                        <th class="next">
-                                            <a title="n&auml;chster Monat" href="tag.php?id=&amp;buergerID=&amp;buergername=&amp;absagecode=&amp;Datum=1446332400&amp;anliegen%5B%5D=120686&amp;dienstleister%5B%5D=122210&amp;dienstleister%5B%5D=122217&amp;dienstleister%5B%5D=122219&amp;dienstleister%5B%5D=122227&amp;dienstleister%5B%5D=122231&amp;dienstleister%5B%5D=122238&amp;dienstleister%5B%5D=122243&amp;dienstleister%5B%5D=122252&amp;dienstleister%5B%5D=122260&amp;dienstleister%5B%5D=122262&amp;dienstleister%5B%5D=122254&amp;dienstleister%5B%5D=122271&amp;dienstleister%5B%5D=122273&amp;dienstleister%5B%5D=122277&amp;dienstleister%5B%5D=122280&amp;dienstleister%5B%5D=122282&amp;dienstleister%5B%5D=122284&amp;dienstleister%5B%5D=122291&amp;dienstleister%5B%5D=122285&amp;dienstleister%5B%5D=122286&amp;dienstleister%5B%5D=122296&amp;dienstleister%5B%5D=150230&amp;dienstleister%5B%5D=122301&amp;dienstleister%5B%5D=122297&amp;dienstleister%5B%5D=122294&amp;dienstleister%5B%5D=122312&amp;dienstleister%5B%5D=122314&amp;dienstleister%5B%5D=122304&amp;dienstleister%5B%5D=122311&amp;dienstleister%5B%5D=122309&amp;dienstleister%5B%5D=317869&amp;dienstleister%5B%5D=324433&amp;dienstleister%5B%5D=325341&amp;dienstleister%5B%5D=324434&amp;dienstleister%5B%5D=324435&amp;dienstleister%5B%5D=122281&amp;dienstleister%5B%5D=324414&amp;dienstleister%5B%5D=122283&amp;dienstleister%5B%5D=122279&amp;dienstleister%5B%5D=122276&amp;dienstleister%5B%5D=122274&amp;dienstleister%5B%5D=122267&amp;dienstleister%5B%5D=122246&amp;dienstleister%5B%5D=122251&amp;dienstleister%5B%5D=122257&amp;dienstleister%5B%5D=122208&amp;dienstleister%5B%5D=122226&amp;herkunft=/terminvereinbarung/">»</a>                                        </th>
-                                    </tr>
-                                    <tr class="dayname">
-                                        <th>Mo</th>
-                                        <th>Di</th>
-                                        <th>Mi</th>
-                                        <th>Do</th>
-                                        <th>Fr</th>
-                                        <th>Sa</th>
-                                        <th><span class="sonnfeiertag">So</span></th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td><span class="sonnfeiertag"><span>1</span></span></td>
-</tr><tr>
-<td class="nichtbuchbar "><span>2</span></td>
-<td class="nichtbuchbar "><span>3</span></td>
-<td class="nichtbuchbar "><span>4</span></td>
-<td class="buchbar "><a class="tagesauswahl" href="termin.php?buergerID=&amp;buergername=&amp;OID=52900%2C54489%2C54574%2C50784%2C54637%2C50792%2C54536%2C54538%2C51456%2C54546%2C54540%2C54542%2C54544%2C54641%2C54033%2C49321%2C49309%2C49334%2C49343%2C54566%2C54568%2C54562%2C54560%2C45160%2C54647%2C54570%2C53880%2C54572%2C53908%2C53907%2C53447%2C53448%2C53433%2C53434%2C53765%2C53766%2C54550%2C54552%2C54554%2C54477%2C54479%2C54481%2C54483%2C54485%2C54524%2C54611%2C54526%2C54614%2C51956%2C54607%2C51627%2C54593%2C54520%2C54495%2C54325%2C54634%2C54601%2C54624%2C52093%2C54230%2C54232%2C54234%2C54206%2C54208%2C54210%2C54212%2C54156%2C54158%2C51543%2C51544%2C51545%2C51521%2C51522%2C51523&amp;datum=2015-11-05&amp;behoerde=&amp;slots=&amp;anliegen%5B%5D=120686&amp;dienstleister%5B%5D=122210&amp;dienstleister%5B%5D=122217&amp;dienstleister%5B%5D=122219&amp;dienstleister%5B%5D=122227&amp;dienstleister%5B%5D=122231&amp;dienstleister%5B%5D=122238&amp;dienstleister%5B%5D=122243&amp;dienstleister%5B%5D=122252&amp;dienstleister%5B%5D=122260&amp;dienstleister%5B%5D=122262&amp;dienstleister%5B%5D=122254&amp;dienstleister%5B%5D=122271&amp;dienstleister%5B%5D=122273&amp;dienstleister%5B%5D=122277&amp;dienstleister%5B%5D=122280&amp;dienstleister%5B%5D=122282&amp;dienstleister%5B%5D=122284&amp;dienstleister%5B%5D=122291&amp;dienstleister%5B%5D=122285&amp;dienstleister%5B%5D=122286&amp;dienstleister%5B%5D=122296&amp;dienstleister%5B%5D=150230&amp;dienstleister%5B%5D=122301&amp;dienstleister%5B%5D=122297&amp;dienstleister%5B%5D=122294&amp;dienstleister%5B%5D=122312&amp;dienstleister%5B%5D=122314&amp;dienstleister%5B%5D=122304&amp;dienstleister%5B%5D=122311&amp;dienstleister%5B%5D=122309&amp;dienstleister%5B%5D=317869&amp;dienstleister%5B%5D=324433&amp;dienstleister%5B%5D=325341&amp;dienstleister%5B%5D=324434&amp;dienstleister%5B%5D=324435&amp;dienstleister%5B%5D=122281&amp;dienstleister%5B%5D=324414&amp;dienstleister%5B%5D=122283&amp;dienstleister%5B%5D=122279&amp;dienstleister%5B%5D=122276&amp;dienstleister%5B%5D=122274&amp;dienstleister%5B%5D=122267&amp;dienstleister%5B%5D=122246&amp;dienstleister%5B%5D=122251&amp;dienstleister%5B%5D=122257&amp;dienstleister%5B%5D=122208&amp;dienstleister%5B%5D=122226&amp;herkunft=%2Fterminvereinbarung%2F" title="An diesem Tag einen Termin buchen " tabindex="3"><u><span>5</span></u></a></td>
-<td class="nichtbuchbar "><span>6</span></td>
-<td class="nichtbuchbar "><span>7</span></td>
-<td><span class="sonnfeiertag"><span>8</span></span></td>
-</tr><tr>
-<td class="buchbar "><a class="tagesauswahl" href="termin.php?buergerID=&amp;buergername=&amp;OID=49388%2C54079%2C54091%2C53222%2C53238%2C53911%2C53912%2C54010%2C53996%2C54067%2C54068%2C47531%2C44626%2C44628%2C54177%2C54155%2C53928%2C54220%2C54221%2C54222%2C54195%2C54196%2C54197%2C54137%2C52494%2C52496%2C52498%2C51464%2C51513%2C51514&amp;datum=2015-11-09&amp;behoerde=&amp;slots=&amp;anliegen%5B%5D=120686&amp;dienstleister%5B%5D=122210&amp;dienstleister%5B%5D=122217&amp;dienstleister%5B%5D=122219&amp;dienstleister%5B%5D=122227&amp;dienstleister%5B%5D=122231&amp;dienstleister%5B%5D=122238&amp;dienstleister%5B%5D=122243&amp;dienstleister%5B%5D=122252&amp;dienstleister%5B%5D=122260&amp;dienstleister%5B%5D=122262&amp;dienstleister%5B%5D=122254&amp;dienstleister%5B%5D=122271&amp;dienstleister%5B%5D=122273&amp;dienstleister%5B%5D=122277&amp;dienstleister%5B%5D=122280&amp;dienstleister%5B%5D=122282&amp;dienstleister%5B%5D=122284&amp;dienstleister%5B%5D=122291&amp;dienstleister%5B%5D=122285&amp;dienstleister%5B%5D=122286&amp;dienstleister%5B%5D=122296&amp;dienstleister%5B%5D=150230&amp;dienstleister%5B%5D=122301&amp;dienstleister%5B%5D=122297&amp;dienstleister%5B%5D=122294&amp;dienstleister%5B%5D=122312&amp;dienstleister%5B%5D=122314&amp;dienstleister%5B%5D=122304&amp;dienstleister%5B%5D=122311&amp;dienstleister%5B%5D=122309&amp;dienstleister%5B%5D=317869&amp;dienstleister%5B%5D=324433&amp;dienstleister%5B%5D=325341&amp;dienstleister%5B%5D=324434&amp;dienstleister%5B%5D=324435&amp;dienstleister%5B%5D=122281&amp;dienstleister%5B%5D=324414&amp;dienstleister%5B%5D=122283&amp;dienstleister%5B%5D=122279&amp;dienstleister%5B%5D=122276&amp;dienstleister%5B%5D=122274&amp;dienstleister%5B%5D=122267&amp;dienstleister%5B%5D=122246&amp;dienstleister%5B%5D=122251&amp;dienstleister%5B%5D=122257&amp;dienstleister%5B%5D=122208&amp;dienstleister%5B%5D=122226&amp;herkunft=%2Fterminvereinbarung%2F" title="An diesem Tag einen Termin buchen " tabindex="3"><u><span>9</span></u></a></td>
-<td><span>10</span></td>
-<td><span>11</span></td>
-<td><span>12</span></td>
-<td><span>13</span></td>
-<td><span>14</span></td>
-<td><span class="sonnfeiertag"><span>15</span></span></td>
-</tr><tr>
-<td><span>16</span></td>
-<td><span>17</span></td>
-<td><span>18</span></td>
-<td><span>19</span></td>
-<td><span>20</span></td>
-<td><span>21</span></td>
-<td><span class="sonnfeiertag"><span>22</span></span></td>
-</tr><tr>
-<td><span>23</span></td>
-<td><span>24</span></td>
-<td><span>25</span></td>
-<td><span>26</span></td>
-<td><span>27</span></td>
-<td><span>28</span></td>
-<td><span class="sonnfeiertag"><span>29</span></span></td>
-</tr><tr>
-<td><span>30</span></td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-                                </tbody>
-                            </table>
-                        </div> <!-- /calendar-month-table END -->
-                </div> <!-- /row-fluid END -->
-            </div> <!-- /calendar-table END -->
-                <div style=\"clear:left;\">
-                    An blau unterlegten und unterstrichenen Tagen sind noch Termine verf&uuml;gbar.<br> 
-                    An rot unterlegten Tagen sind alle Termine ausgebucht.<br> 
-                    An wei&szlig; unterlegten Tagen sind noch keine Termine zur Buchung freigegeben.
-                </div>
-    </div> <!-- /collapsible-body End -->
-</div> <!-- /collapsible-group  End  ////////////////////////////////////////////////////// -->
+                    <!--NAVIGATION END: horizontal-->
+
+                    <!-- content start -->
+                    <!-- row - span12 -->
+
+                    <div class="row row-breadcrumb noprint">
+                        <div class="span10">
+                            <div class="html5-section breadcrumb">
+                                <ul>
+                                    <li><a href="https://service.berlin.de" class="homehaus">Service Berlin</a></li>
+                                    <li><a href="https://service.berlin.de/terminvereinbarung/" class="pos1">Terminvereinbarung</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
 
 
+                    <div class="row">
+                        <div class="span2 column-left">
+                            <!-- NAVIGATION BEGIN: vertical -->
+                            <div class="html5-nav content-navigation-left navbar">
+                                <div class="navbar-inner">
+                                    <nav class="hidden-phone nav-collapse collapse" aria-label="Sekund&#228;re Navigation">
+                                        <h6 class="aural">Sekund&#228;re Navigation</h6>
+                                        <ul class="nav level-0">
+                                            <li class="active"><a href="https://service.berlin.de/terminvereinbarung/">Termin&#173;vereinbarung</a>
+                                                <ul class="level-1">
+                                                    <li>
+                                                        <a href="https://service.berlin.de/terminvereinbarung/hinweise/">Hinweise</a>
+                                                    </li>
+                                                    <li>
+                                                        <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php">Termin
+                                                            &#228;ndern</a> </li>
+                                                    <li>
+                                                        <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/">Datenschutz&#173;erkl&#228;rung</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </nav>
+                                </div>
+                            </div>
+                            <!-- NAVIGATION END: vertical -->
 
 
-</div> <!-- HHI BODY End: all HHI contents  -->
-<br /><br />
-
-
-        </div><!-- /html5-section -->
-
-            </div>
-    
-    <!-- INCLUDE BEGIN: Infocolumn -->
-<div class="span3 column-right html5-aside" role="complementary">
-    <p class="aural">Es folgen die Inhalte der rechten Seitenspalte</p>
-    <div class="html5-section content-marginal">
-
-
-                        <!-- FLEX BEGIN: ContactInclude --><div class="html5-section modul-contactinclude"><!--FLEX BEGIN: Text/Bild-->
-<div class="html5-section block modul-text_bild float">    <div class="html5-header header">
-                        <h3 class="title">Diensteanbieter</h3>    </div>
-<div class="html5-figure image main-image type-teaser" style="">
-<a href="http://www.itdz-berlin.de/" target="_blank" title="Detailseite (Öffnet in neuem Fenster)">    <img
-        src="/converjon/?ts=1396904914&#38;height=125&#38;width=166&#38;url=https%3A%2F%2Fservice.berlin.de%2F_assets%2Flogo_itdz.png&#38;mime=image%2Fpng"
-        alt="Link zu: Detailseite (Öffnet in neuem Fenster)"
-        title="Detailseite (Öffnet in neuem Fenster)"
-                    />
-</a>
-
-</div>
-    <div class="html5-section body">
-                <div class="text ">
-            <div class="textile">
-  <p>
-    Das <span class="caps">ITDZ</span> Berlin &#8211; der
-    Lösungspartner für die moderne Verwaltung
-  </p>
-</div>        </div>
-               </div>
-</div>
-<!--FLEX END: Text/Bild-->
-</div><!-- FLEX END: ContactInclude --><!-- FLEX BEGIN: ContactInclude --><div class="html5-section modul-contactinclude"></div><!-- FLEX END: ContactInclude -->    </div>
-</div>
-<!-- INCLUDE END: Infocolumn -->
-</div>
-
-<!--    container-wrapper + container + row + span12 -->
-
-                                                <div class="row">
-                            <div class="span12">
-                                <div class="html5-footer content-footer" role="contentinfo">
-                                                                        <!-- NAVIGATION BEGIN: footer -->
-
-    <div class="html5-nav">
-        <ul class="nav">
-            <li class="icon-footer icon-imprint_32"><a href="https://service.berlin.de/hinweise/artikel.2696.php" >Impressum</a></li>
-            <li class="right icon-footer icon-printer_32"><a href="javascript:window.print();">Druckversion</a></li>
-            <li class="right icon-footer icon-totop"><a href="#top">zum Seitenanfang</a></li>
-        </ul>
-    </div>
-
-<!-- NAVIGATION END: footer -->
-                                                                        <div class="section_splitter hidden-desktop hidden-tablet"></div>
-                                    <div class="html5-nav meta-navi hidden-desktop hidden-tablet">
-                                        <ul class="nav">
-                                                                                    </ul>
+                        </div>
+                        <div class="span7 column-content">
+                            <div class="html5-section article" role="main">
+                                <div class="zms">
+                                    <div class="html5-header header">
+                                        <h1 class="title">Terminvereinbarung</h1>
                                     </div>
-                                                                    </div>
+
+                                    <div class="collapsible-group closed">
+                                        <div class="collapsible-heading row-fluid">
+                                            <div class="collapsible-toggle">
+                                                <div class="table-cell collapsible-counter span1">1</div>
+                                                <div class="table-cell collapsible-title span3">Dienstleistung</div>
+                                                <div class="table-cell collapsible-description span7">
+                                                    <ul class="list-bullet">
+                                                        <li data-url="https://service.berlin.de/dienstleistung/120703/">
+                                                            Personalausweis beantragen</li>
+                                                    </ul>
+
+                                                </div>
+                                                <div class="table-cell collapsible-options span1">
+                                                    <a href="https://service.berlin.de/dienstleistungen/" class="edit icon-pencil" title="Zur Dienstleistungsauswahl">Bearbeiten</a>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+
+                                    <div class="collapsible-group">
+                                        <div class="collapsible-heading row-fluid">
+                                            <div class="collapsible-toggle">
+                                                <div class="table-cell collapsible-counter span1">2</div>
+                                                <div class="table-cell collapsible-title span11">Datum</div>
+                                                <div class="table-cell collapsible-description span7">
+
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+
+
+                                    <div class="collapsible-body">
+                                        <div class="calendar-table">
+                                            <div class="calendar-head">
+                                                <h2 class="title">Bitte wählen Sie ein Datum:</h2>
+                                                <div class="calendar-legend">
+                                                    <span class="legend-element"><span
+                                                            class="legend-color buchbar">&nbsp;</span>verfügbar</span>
+                                                    <span class="legend-element"><span
+                                                            class="legend-color nichtbuchbar">&nbsp;</span>ausgebucht</span>
+                                                </div>
+                                            </div>
+                                            <div class="row-fluid">
+                                                <div class="calendar-month-table span6">
+                                                    <table>
+                                                        <thead>
+                                                            <tr class="controll">
+                                                                <th class="prev">
+                                                                </th>
+                                                                <th colspan="5" class="month">August 2020</th>
+                                                                <th>&nbsp;</th>
+                                                            </tr>
+                                                            <tr class="dayname">
+                                                                <th>Mo</th>
+                                                                <th>Di</th>
+                                                                <th>Mi</th>
+                                                                <th>Do</th>
+                                                                <th>Fr</th>
+                                                                <th>Sa</th>
+                                                                <th><span class="sonnfeiertag">So</span></th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <tr>
+                                                                <td colspan="5"></td>
+                                                                <td class="">01</td>
+
+
+
+
+                                                                <td class="">02</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="">03</td>
+
+
+
+
+                                                                <td class="">04</td>
+
+
+
+
+                                                                <td class="">05</td>
+
+
+
+
+                                                                <td class="">06</td>
+
+
+
+
+                                                                <td class="">07</td>
+
+
+
+
+                                                                <td class="">08</td>
+
+
+
+
+                                                                <td class="">09</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="">10</td>
+
+
+
+
+                                                                <td class="">11</td>
+
+
+
+
+                                                                <td class="">12</td>
+
+
+
+
+                                                                <td class="">13</td>
+
+
+
+
+                                                                <td class="">14</td>
+
+
+
+
+                                                                <td class="">15</td>
+
+
+
+
+                                                                <td class="">16</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="">17</td>
+
+
+
+
+                                                                <td class="">18</td>
+
+
+
+
+                                                                <td class="">19</td>
+
+
+
+
+                                                                <td class="">20</td>
+
+
+
+
+                                                                <td class="">21</td>
+
+
+
+
+                                                                <td class="">22</td>
+
+
+
+
+                                                                <td class="">23</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="">24</td>
+
+
+
+
+                                                                <td class="">25</td>
+
+
+
+
+                                                                <td class="">26</td>
+
+
+
+
+                                                                <td class="">27</td>
+
+
+
+
+                                                                <td class="">28</td>
+
+
+
+
+                                                                <td class="">29</td>
+
+
+
+
+                                                                <td class=" heutemarkierung">30</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="nichtbuchbar">31</td>
+
+
+                                                                <td colspan="6">&nbsp;</td>
+
+
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                                <div class="calendar-month-table span6">
+                                                    <table>
+                                                        <thead>
+                                                            <tr class="controll">
+                                                                <th>&nbsp;</th>
+                                                                <th colspan="5" class="month">September 2020</th>
+                                                                <th class="next">
+                                                                    <a title="nächster Monat ab (01-10-2020)" href="/terminvereinbarung/termin/day/1598911200/">»</a>
+                                                                </th>
+                                                            </tr>
+                                                            <tr class="dayname">
+                                                                <th>Mo</th>
+                                                                <th>Di</th>
+                                                                <th>Mi</th>
+                                                                <th>Do</th>
+                                                                <th>Fr</th>
+                                                                <th>Sa</th>
+                                                                <th><span class="sonnfeiertag">So</span></th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <tr>
+                                                                <td colspan="1"></td>
+                                                                <td class="buchbar" title="An diesem Tag einen Termin buchen"><a title="An diesem Tag einen Termin buchen" href="/terminvereinbarung/termin/time/1598911200/">01</a>
+                                                                </td>
+
+
+
+
+                                                                <td class="nichtbuchbar">02</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">03</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">04</td>
+
+
+
+
+                                                                <td class="">05</td>
+
+
+
+
+                                                                <td class="">06</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="nichtbuchbar">07</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">08</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">09</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">10</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">11</td>
+
+
+
+
+                                                                <td class="">12</td>
+
+
+
+
+                                                                <td class="">13</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="nichtbuchbar">14</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">15</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">16</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">17</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">18</td>
+
+
+
+
+                                                                <td class="">19</td>
+
+
+
+
+                                                                <td class="">20</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="nichtbuchbar">21</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">22</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">23</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">24</td>
+
+
+
+
+                                                                <td class="nichtbuchbar">25</td>
+
+
+
+
+                                                                <td class="">26</td>
+
+
+
+
+                                                                <td class="">27</td>
+
+
+
+                                                            </tr>
+                                                            <tr>
+
+                                                                <td class="">28</td>
+
+
+
+
+                                                                <td class="">29</td>
+
+
+
+
+                                                                <td class="">30</td>
+
+
+                                                                <td colspan="4">&nbsp;</td>
+
+
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div style="clear:left; background:url(/terminvereinbarung/termin/blank.png);">
+                                        An blau unterlegten und unterstrichenen Tagen sind noch Termine verfügbar.<br> An rot unterlegten Tagen sind alle Termine ausgebucht.<br> An weiß unterlegten Tagen sind noch keine Termine zur Buchung freigegeben.
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+                        <!-- INCLUDE BEGIN: Infocolumn -->
+
+                        <div class="span3 column-right html5-aside" role="complementary">
+                            <h2 class="aural">Es folgen die Inhalte der rechten Seitenspalte</h2>
+                            <div class="html5-section content-marginal">
+
+
+
+
+                                <!--FLEX BEGIN: Text/Bild-->
+                                <div class="html5-section block modul-text_bild">
+                                    <div class="html5-header header">
+                                        <h2 class="title" id="headline_8_0">Vorzugstermine:</h2>
+                                    </div>
+                                    <div class="html5-section body">
+                                        <div class="text ">
+                                            <div class="textile">
+                                                <ul>
+                                                    <li>
+                                                        <a href="https://service.berlin.de/terminvereinbarung/hinweise/#vorzugstermine">Hinweis
+                                                            zu Vorzugstermin-Standorten der Bürgerämter</a>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!--FLEX END: Text/Bild-->
+                                <!-- FLEX BEGIN: ContactInclude -->
+                                <div class="html5-section modul-contactinclude">
+                                    <!--FLEX BEGIN: Text/Bild-->
+                                    <div class="html5-section block modul-text_bild float">
+                                        <div class="html5-header header">
+                                            <h2 class="title" id="headline_2_0">Bürgertelefon 115</h2>
+                                        </div>
+                                        <div class="html5-figure image
+     main-image type-teaser" style="">
+                                            <img src="https://service.berlin.de/converjon/?ts=1435756104&#38;width=166&#38;height=125&#38;mime=image%2Fpng&#38;url=https%3A%2F%2Fservice.berlin.de%2Flandalle9%2F_assets%2F115_logo_contact.png%3Fts%3D1435756104.png" alt="Logo B&#252;rgertelefon 115"
+                                                loading="lazy" />
+
+                                            <div class="caption">
+
+                                                <span class="copyright">Bild: BMI</span>
+
+                                            </div>
+
+                                        </div>
+                                        <div class="html5-section body">
+                                            <div class="text ">
+                                                <div class="textile">
+                                                    <p>
+                                                        Die durch die Corona-Pandemie ausgelösten Ereignisse führen zu einem hohen Anrufaufkommen und leider zu Einschränkungen der Erreichbarkeit des Bürgertelefons 115. Bitte nutzen Sie auch die
+                                                        <a href="https://service.berlin.de/standorte/">schriftlichen
+                                                            Kontaktwege der Behörden</a>.
+                                                    </p>
+                                                    <p>
+                                                        Telefon: (030) 115
+                                                    </p>
+                                                    <p>
+                                                        Montag &#8211; Freitag von<br /> 08:00 bis 18:00 Uhr
+                                                    </p>
+                                                    <ul>
+                                                        <li>
+                                                            <a href="https://www.berlin.de/115">Bürgertelefon 115</a>
+                                                        </li>
+                                                        <li>
+                                                            <a href="https://service.berlin.de/chatbot/chatbot-bobbi-606279.php" title="Betaversion des Chatbots Bobbi">Chatbot Bobbi
+                                                                (beta)</a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!--FLEX END: Text/Bild-->
+                                </div>
+                                <!-- FLEX END: ContactInclude -->
+                            </div>
+                        </div>
+                        <!-- INCLUDE END: Infocolumn -->
+
+
+                    </div>
+                    <!--    container-wrapper + container + row + span12 -->
+
+                    <div class="row">
+                        <div class="span12">
+                            <div class="html5-footer content-footer" role="contentinfo">
+                                <!-- NAVIGATION BEGIN: footer -->
+                                <div class="html5-nav">
+                                    <ul class="nav">
+                                        <li><a href="https://service.berlin.de/hinweise/artikel.2696.php" class="ic-fa-impressum">Impressum</a></li>
+                                        <li class="right"><a class="ic-fa-print" href="javascript:window.print();">Druckversion</a></li>
+                                        <li class="right"><a class="ic-fa-totop" href="#top">zum Seitenanfang</a></li>
+                                    </ul>
+                                </div>
+
+                                <!-- NAVIGATION END: footer -->
+
+                                <div class="section_splitter hidden-desktop hidden-tablet"></div>
+                                <div class="html5-nav meta-navi hidden-desktop hidden-tablet">
+                                    <ul class="nav">
+                                    </ul>
+                                </div>
+
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-
-                        <div class="container-wrapper container-footer">
-            <div class="container">
-                <div class="row">
-                    <div class="span12">
-                        
-<!-- template start: portal-footer -->
-<div class="html5-footer portal-footer">
-    <div>
-        <div class="textile">
-  <p>
-    Diese Seiten werden verantwortet durch die Senatskanzlei des
-    Regierenden Bürgermeisters.
-  </p>
-</div>        <p>
-            Berlin.de ist ein Angebot des Landes Berlin und der BerlinOnline Stadtportal GmbH & Co. KG.            Weitere Informationen hierzu finden Sie im <a href="http://www.berlin.de/wir-ueber-uns-be/impressum/"> Impressum </a>.        </p>
     </div>
-    <div class="html5-nav">
-        <ul class="nav">
-            <li>Weitere Metropol-Webseiten:</li>
-            <li><a href="http://www.hamburg.de/">Hamburg</a></li>
-            <li><a href="http://www.muenchen.de/">München</a></li>
-            <li><a href="http://www.koeln.de/">Köln</a></li>
+
+
+    <!-- MOBILE NAVIGATION START -->
+    <div class="navigation-mobile hidden-desktop hidden-tablet" role="navigation">
+        <p class="navSkip">Navigiere direkt zu:</p>
+        <ul class="navSkip">
+            <li><a href="#mobile-nav-toggle" tabindex="1" id="hiddenNavToggler">Navigation
+                    <!-- append text per css here --></a></li>
         </ul>
-    </div><!-- /html5-nav -->
-</div><!-- /html5-footer -->
-<!-- /template end: portal-footer -->
-                    </div>
-                </div>
-            </div>
-        </div>
-                        
-        <div class="navigation-mobile hidden-desktop hidden-tablet" role="navigation">
-            <p class="navSkip">Navigiere direkt zu:</p>
-            <ul class="navSkip">
-                <li><a href="#mobile-nav-toggle" tabindex="1">Navigation <!-- append text per css here --></a></li>
-            </ul>
-            <div class="sticky-header bde-gradient">
-                <div class="red-line"></div>
-                                <div class="portal-logo">
-                    <a title="Link führt zur Startseite von Berlin.de" href="http://www.berlin.de" >
-                        <img title="Link führt zur Startseite von Berlin.de" alt="Bild zeigt: Berlin.de Logo" src="//service.berlin.de/i9f/images/berlin_de.png" />
-                    </a>
-                </div>
-                                <button class="btn nav-toggle" id="mobile-nav-toggle">
-                    <span class="icon-menu"> 
-                        <span class="line line-1"></span>
-                        <span class="line line-2"></span>
-                        <span class="line line-3"></span>
-                    </span>
-                </button>
-            </div>
-            <div class="wrapper">
-                <div class="sticky-container-head">
-                    <div class="offcanvas-search">
-                    <form class="institutionssuche institutionssuche-mobile" method="get" action="https://service.berlin.de/suche/stichwort/">
-    <div class="control-group searchform mobile" role="search">
-        <p class="aural" id="aural_institutionssuche_mobile">
-            Suche auf der Internetseite 'Service-Portal Berlin':        </p>
-        <input type="search" placeholder="Suchbegriff"
-            name="x" aria-labelledby="aural_institutionssuche_mobile"
-            maxlength="255"
-            title="Hier können Sie einen Text eingeben, um die Internetseite 'Service-Portal Berlin' zu durchsuchen"
-        />
-        <button class="btn global-search-submit" type="submit">
-            <i class="icon-search icon-white"></i>
-            <span class="hidden-phone">Suchen</span>
+
+        <button class="btn nav-toggle" id="mobile-nav-toggle" title="Mobile Navigation" aria-labelledby="hiddenNavToggler">
+            <span class="aural">Öffnet und schließt die mobile Navigation</span>
+            <span class="icon-menu">
+                <span class="line line-1"></span>
+                <span class="line line-2"></span>
+                <span class="line line-3"></span>
+            </span>
         </button>
-    </div>
-</form>
-                    </div>
+
+        <div class="wrapper">
+            <div class="sticky-container-head">
+                <div class="offcanvas-search">
+                    <form class="institutionssuche institutionssuche-mobile" method="get" action="https://service.berlin.de/suche/stichwort/">
+                        <div class="control-group searchform mobile" role="search">
+                            <label class="aural" id="aural_institutionssuche_mobile">
+                                Suche auf der Internetseite &#34;Service-Portal Berlin&#34;: </label>
+                            <input type="search" placeholder="Suchbegriff" name="x" aria-labelledby="aural_institutionssuche_mobile" maxlength="255" title="Hier k&#246;nnen Sie einen Text eingeben, um die Internetseite &#34;Service-Portal Berlin&#34; zu durchsuchen" />
+                            <button class="btn global-search-submit" type="submit">
+                                <span class="hidden-phone">Suchen</span>
+                            </button>
+                        </div>
+                    </form>
                 </div>
-                <div class="nav-container">
-                    <div class="nav-container-body">
-                        <ul class="nav-menu menu">
-                            <li class="menu-item has-dropdown">
-                                <a href="#!" class="menu-link">
-                                    Service-Portal Berlin                                </a>
-                                <ul class="nav-dropdown menu">
-                                    <li class="menu-item">
-                                        <a href="https://service.berlin.de/" class="menu-link" title="Link zu: Startseite von Service-Portal Berlin">Service-Portal Berlin: Startseite</a>                                        <ul class="nav">        <li class=" menu-item">
-            <a href="https://service.berlin.de/themen/" class=" menu-link">Themen</a>                    </li>
-        <li class=" menu-item">
-            <a href="https://service.berlin.de/dienstleistungen/" class=" menu-link">Dienst&shy;leistungen</a>                    </li>
-        <li class=" menu-item">
-            <a href="https://service.berlin.de/standorte/" class=" menu-link">Standorte</a>                    </li>
-        <li class=" menu-item active">
-            <a href="https://service.berlin.de/terminvereinbarung/" class=" menu-link">Termin&shy;vereinbarung</a>                    </li>
-        <li class=" menu-item">
-            <a href="https://service.berlin.de/onlineverfahren-onlinedienstleistungen/" class=" menu-link">Online-Verfahren</a>                    </li>
-        <li class=" menu-item">
-            <a href="https://service.berlin.de/app/" class=" menu-link">App</a>                    </li>
-</ul>                                    </li>
-                                </ul>
-<!-- HIER 1 -->
-                                
-		<ul class="sub crumbs1">
-			<li class="menu-item has-no-dropdown">
-<a href="https://service.berlin.de/terminvereinbarung/" class="menu-link">Termin&shy;vereinbarung</a><ul class="sub level-1">
-<li class="menu-item has-no-dropdown">
-    <a href="https://service.berlin.de/terminvereinbarung/hinweise/" class="menu-link">Hinweise</a>
-    </li>
-<li class="menu-item has-no-dropdown">
-    <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php" class="menu-link">Termin ändern</a>
-    </li>
-<li class="menu-item has-no-dropdown">
-    <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/" class="menu-link">Datenschutz&shy;erklärung</a>
-    </li>
-</ul><!-- class="sub level-1" -->
-			</li>
-		</ul><!-- crumbs1 -->
-<!-- HIER 2 -->
-                            </li>
-                        </ul>
-                    </div>
+            </div>
+
+            <div class="nav-container">
+                <div class="nav-container-body">
+                    <ul class="nav-menu menu">
+                        <li class="menu-item has-dropdown ">
+                            <a href="#!" class="menu-link">
+                                Service-Portal Berlin </a>
+                            <!-- HIER 0 -->
+                            <ul class="nav-dropdown menu ">
+                                <li class="menu-item">
+                                    <a href="https://service.berlin.de/" class="menu-link" title="Link zu: Startseite von &#34;Service-Portal Berlin&#34;">Service-Portal
+                                        Berlin: Startseite</a>
+                                    <ul class="nav">
+                                        <li class=" menu-item">
+                                            <a href="https://service.berlin.de/dienstleistungen/" class=" menu-link">Dienst&#173;leistungen</a> </li>
+                                        <li class=" menu-item">
+                                            <a href="https://service.berlin.de/standorte/" class=" menu-link">Standorte</a> </li>
+                                        <li class=" menu-item active">
+                                            <a href="https://service.berlin.de/terminvereinbarung/" class=" menu-link">Termin&#173;vereinbarung</a> </li>
+                                        <li class=" menu-item">
+                                            <a href="https://service.berlin.de/onlineverfahren-onlinedienstleistungen/" class=" menu-link">Online-Verfahren</a> </li>
+                                        <li class=" menu-item">
+                                            <a href="https://service.berlin.de/app/" class=" menu-link">App</a> </li>
+                                        <li class=" menu-item">
+                                            <a href="https://service.berlin.de/themen/" class=" menu-link">Themen</a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                            <!-- HIER 1 -->
+
+                            <ul class="sub crumbs1">
+                                <li class="menu-item has-no-dropdown">
+                                    <a href="https://service.berlin.de/terminvereinbarung/" class="menu-link">Termin&#173;vereinbarung</a>
+                                    <ul class="sub level-1">
+                                        <li class="menu-item has-no-dropdown">
+                                            <a href="https://service.berlin.de/terminvereinbarung/hinweise/" class="menu-link">Hinweise</a>
+                                        </li>
+                                        <li class="menu-item has-no-dropdown">
+                                            <a href="https://service.berlin.de/terminvereinbarung/termin/terminaendern.php" class="menu-link">Termin &#228;ndern</a>
+                                        </li>
+                                        <li class="menu-item has-no-dropdown">
+                                            <a href="https://service.berlin.de/terminvereinbarung/datenschutzerklaerung/" class="menu-link">Datenschutz&#173;erkl&#228;rung</a>
+                                        </li>
+                                    </ul>
+                                    <!-- class="sub level-1" -->
+                                </li>
+                            </ul>
+                            <!-- crumbs1 -->
+                            <!-- HIER 2 -->
+                        </li>
+                    </ul>
+
                 </div>
             </div>
         </div>
-
-        <script type="text/javascript" src="//service.berlin.de/i9f/v4/js/bo-foot.js?ts=1441880898"></script>
-
-<!-- Werbung -->
-
-<!-- Zählpixel -->
-
-<div id="cp">
-<script type="text/javascript">/*<![CDATA[*/
-if (typeof(DartIvwKategorie) == "undefined") DartIvwKategorie="beberlin";
+    </div>
+    <!-- MOBILE NAVIGATION END -->
 
 
-var CP = location.protocol+"//boss.berlinonline.de/cp.php?a=berlin&amp;r="+escape(document.referrer)+"&amp;cat="+DartIvwKategorie+"&amp;p="+escape(document.location)+"&amp;d="+(Math.random()*100000);
-document.write("<img src=\""+CP+"\" width=\"1\" height=\"1\" alt=\"\" id=\"cp_pixel\" style=\"position:absolute;width:1px;height:1px;\" />");
-/*]]>*/</script>
-<noscript><img src="https://boss.berlinonline.de/cp.php?a=berlin&amp;p=https%3A%2F%2Fservice.berlin.de%2Fservice.berlin.de%2Fterminvereinbarung%2F__i9%2Fstd%2Ffoot.inc&amp;r=http%3A%2F%2Fservice.berlin.de%2Fdienstleistung%2F120918%2Fstandort%2F121362%2F" alt="" /></noscript>
+    <div class="container-wrapper container-footer">
+        <div class="container">
+            <div class="row">
+                <div class="span12">
 
-    <div id="ivw">
+                    <!-- template start: portal-footer -->
+                    <div class="html5-footer portal-footer">
+                        <div>
+                            <div class="textile">
+                                <p>
+                                    Diese Seiten werden verantwortet durch die Senatsverwaltung für Inneres und Sport.
+                                </p>
+                            </div>
+                            <p>
+                                Berlin.de ist ein Angebot des Landes Berlin und der BerlinOnline Stadtportal GmbH &#38; Co. KG. Weitere Informationen hierzu finden Sie im <a href="https://www.berlin.de/wir-ueber-uns-be/impressum/">Impressum</a>. </p>
+                        </div>
+                        <div class="html5-nav">
+                            <ul class="nav">
+                                <li>Weitere Metropol-Webseiten:</li>
+                                <li><a href="https://www.hamburg.de/">Hamburg</a></li>
+                                <li><a href="https://www.muenchen.de/">M&#252;nchen</a></li>
+                                <li><a href="https://www.koeln.de/">K&#246;ln</a></li>
+                            </ul>
+                        </div>
+                        <!-- /html5-nav -->
+                    </div>
+                    <!-- /html5-footer -->
+                    <!-- /template end: portal-footer -->
+                </div>
+            </div>
+        </div>
+    </div>
 
-         <!-- szm pixel desktop variante -->
-<!-- SZM VERSION="2.0" -->
-<script type="text/javascript" src="https://script.ioam.de/iam.js"></script>
-<script type="text/javascript">
-var iam_data = {"mg":"yes","cp":DartIvwKategorie,"oc":DartIvwKategorie,"st":"berlin","sv":(location.pathname=="/"?"ke":"in"),"co":location.hostname}
-iom.c(iam_data,1);
-</script>
-<!-- /SZM -->
+    <script src="//service.berlin.de/i9f/v4/js/bo-foot.js?ts=1598457878"></script>
+
+
+    <!-- Zaehlpixel -->
+
+    <div id="cp">
+        <script>
+            /*<![CDATA[*/
+            if (typeof(DartIvwKategorie) == "undefined") DartIvwKategorie = "beberlin";
+
+            /*]]>*/
+        </script>
 
     </div>
-</div>
+    <!-- /Zaehlpixel -->
 
-
-<!-- Piwik -->
-<script type="text/javascript">
-  var _paq = _paq || [];
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.berlinonline.de"]);
-  _paq.push(["trackPageView"]);
-  _paq.push(["enableLinkTracking"]);
-
-  (function() {
-    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://piwik.berlinonline.de/";
-    _paq.push(["setTrackerUrl", u+"piwik.php"]);
-    _paq.push(["setSiteId", document.location.hostname.match(/service\.berlin\.de$/) ? "6" : "1"]);
-    var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
-    g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<!-- End Piwik Code -->
-
-
-
-
+    <script type="text/javascript">
+        window.bolocal = {
+            "zmsappointment": {
+                "getIncludepath": function() {
+                    return "/terminvereinbarung/termin";
+                }
+            }
+        };
+    </script>
+    <script type="text/javascript" src="/terminvereinbarung/termin/_js/index.js"></script>
 </body>
-</html>
 
- 
+</html>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler.require(:default, :development)

--- a/spec/termin_de/calendar_spec.rb
+++ b/spec/termin_de/calendar_spec.rb
@@ -1,29 +1,32 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe TerminDe::Calendar do
+  # the sample calendar is used which returns 2020-09-01 as bookable
+  describe '#earlier?' do
+    let(:options) do
+      TerminDe::Cli::Options.new(booked_termin_date, true, '12345')
+    end
 
-  describe '#has_earlier?' do
-    let(:options) { TerminDe::Cli::Options.new(booked_termin_date, true) }
-
-    subject { described_class.new(options).has_earlier? }
+    subject { described_class.new(options).earlier? }
 
     context 'when the booked termin is later than the available termins' do
-      let(:booked_termin_date) { Date.new(2015, 11, 10) }
+      let(:booked_termin_date) { Date.new(2020, 9, 2) }
 
       it { is_expected.to be_truthy }
     end
 
     context 'when the booked termin is earlier than the available termins' do
-      let(:booked_termin_date) { Date.new(2015, 11, 4) }
+      let(:booked_termin_date) { Date.new(2020, 8, 31) }
 
       it { is_expected.to be_falsy }
     end
 
     context 'when the booked termin is equal than the earlier available termin' do
-      let(:booked_termin_date) { Date.new(2015, 11, 5) }
+      let(:booked_termin_date) { Date.new(2020, 9, 1) }
 
       it { is_expected.to be_falsy }
     end
   end
-
 end

--- a/spec/termin_de_spec.rb
+++ b/spec/termin_de_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe TerminDe do

--- a/termin_de.gemspec
+++ b/termin_de.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Strech/termin_de'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split('\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'bin'
   spec.executables   = ['termin_de']
   spec.require_paths = ['lib']
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '>= 1.6.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'pry', '~> 0.10'
 end

--- a/termin_de.gemspec
+++ b/termin_de.gemspec
@@ -1,29 +1,30 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'termin_de/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "termin_de"
+  spec.name          = 'termin_de'
   spec.version       = TerminDe::VERSION
-  spec.authors       = ["Strech (Sergey Fedorov)"]
-  spec.email         = ["oni.strech@gmail.com"]
+  spec.authors       = ['Strech (Sergey Fedorov)']
+  spec.email         = ['oni.strech@gmail.com']
 
-  spec.summary       = "Simple termin monitor"
-  spec.description   = "Monitoring termin cancelation for Burgeramt"
-  spec.homepage      = "https://github.com/Strech/termin_de"
-  spec.license       = "MIT"
+  spec.summary       = 'Simple termin monitor'
+  spec.description   = 'Monitoring termin cancelation for Burgeramt'
+  spec.homepage      = 'https://github.com/Strech/termin_de'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "bin"
-  spec.executables   = ["termin_de"]
-  spec.require_paths = ["lib"]
+  spec.files         = `git ls-files -z`.split('\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = 'bin'
+  spec.executables   = ['termin_de']
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "curb", ">= 0.8.8"
-  spec.add_dependency "nokogiri", ">= 1.6.6"
+  spec.add_dependency 'curb', '>= 0.8.8'
+  spec.add_dependency 'nokogiri', '>= 1.6.6'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'pry', '~> 0.10'
 end


### PR DESCRIPTION
I updated the gem to handle the 2020 service.berlin webpage correctly to scrap for bookable appointments. 
Furthermore I added the cli parameter to specify the service the scrapper should look for and restructured it a little bit and.

- tests run without error
- setup on a new machine without errors
