### PR TITLE
Fix undefined `to_h` method in Termin class

### DIFF
--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -14,7 +14,7 @@ module TerminDe
     end
 
     def to_h
-      {:link => @link,:date => @date}
+      {link: @link, date: @date}
     end
   end
 end

--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -12,5 +12,9 @@ module TerminDe
       @link = link
       @service = service
     end
+
+    def to_h
+      {:link => @link,:date => @date}
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a bug when passing a custom command to the CLI. For example, if you wanted to automatically open a link when a termin is found:

```
$ termin_de --dry-run -c "open '%{link}'"
```

The command template is [passed the result of `termin.to_h`](https://github.com/Strech/termin_de/blob/bb0b47c05fc0dc077a263aac4b369a872e831c21/lib/termin_de/loop.rb#L59), but currently `to_h` is undefined, so the tool crashes. I see that in the past the `Termin` class used a struct which would have had `to_h` defined by default, but this is no longer the case, so I’ve added a simple implementation.

These are probably the first lines of Ruby I’ve ever written, so there a might be a nicer way of converting public class properties to a hash, but I can confirm this works :-)