### PR TITLE
Add support to after date

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Or install it yourself as:
 
 ```
 Usage: termin [options]
+    -a, --after=<date>               Trigger only on date later than given date
     -b, --before=<date>              Trigger only on date earlier than given date
     -c, --execute=<command>          Run given command with %{date} and %{link} replacements
     -s, --service=<id>               Id of the requested service
@@ -34,7 +35,7 @@ Usage: termin [options]
 
 Basically you can sit down, relax, brew some :coffee: and watch at output.
 
-    $ termin_de --before 2020-09-29
+    $ termin_de --before 2020-09-29 --after 2020-09-20
     $ I, [2020-09-01 20:24:52#30369]  INFO -- : Looking for available slots before 2020-09-29
     $ I, [2020-09-01 20:24:53#30369]  INFO -- : Nothing ...
     $ I, [2020-09-01 20:25:53#30369]  INFO -- : Looking for available slots before 2020-09-29

--- a/lib/termin_de/cli.rb
+++ b/lib/termin_de/cli.rb
@@ -6,7 +6,8 @@ require 'date'
 module TerminDe
   # command line interface
   class Cli
-    DEFAULT_DATE = Date.new(3000, 0o1, 0o1)
+    DEFAULT_BEFORE_DATE = Date.new(3000, 0o1, 0o1)
+    DEFAULT_AFTER_DATE = Date.new(1970, 0o1, 0o1)
     DEFAULT_DRY_RUN = false
     # default request for id card
     DEFAULT_SERVICE = '120703'
@@ -20,7 +21,13 @@ module TerminDe
 
     def initialize(argv)
       @argv = argv
-      @options = Options.new(DEFAULT_DATE, DEFAULT_DRY_RUN, DEFAULT_SERVICE, BURGERAMT_IDS)
+      @options = Options.new(
+        DEFAULT_BEFORE_DATE,
+        DEFAULT_AFTER_DATE,
+        DEFAULT_DRY_RUN,
+        DEFAULT_SERVICE,
+        BURGERAMT_IDS
+      )
     end
 
     def start
@@ -30,7 +37,7 @@ module TerminDe
 
     private
 
-    Options = Struct.new(:before_date, :dry_run, :service, :burgeramt, :command) do
+    Options = Struct.new(:before_date, :after_date, :dry_run, :service, :burgeramt, :command) do
       def command_given?
         !command.nil?
       end
@@ -43,11 +50,19 @@ module TerminDe
         parser.banner = "Burgeramt termin monitor\nUsage: termin [options]"
         parser.version = VERSION
 
+        parser.on('-a', '--after=<date>', String, 'Trigger only on date later than given date') do |date|
+          @options.after_date = begin
+                                  Date.parse(date)
+                                rescue StandardError
+                                  DEFAULT_AFTER_DATE
+                                end
+        end
+
         parser.on('-b', '--before=<date>', String, 'Trigger only on date earlier than given date') do |date|
           @options.before_date = begin
                                    Date.parse(date)
                                  rescue StandardError
-                                   DEFAULT_DATE
+                                   DEFAULT_BEFORE_DATE
                                  end
         end
 

--- a/lib/termin_de/loop.rb
+++ b/lib/termin_de/loop.rb
@@ -35,7 +35,7 @@ module TerminDe
 
     def infinitly
       loop do
-        @logger.info "Looking for available slots before #{@options.before_date}"
+        @logger.info "Looking for available slots after #{@options.after_date} and before #{@options.before_date}"
         begin
           yield
         rescue Exception => e

--- a/lib/termin_de/termin.rb
+++ b/lib/termin_de/termin.rb
@@ -13,6 +13,10 @@ module TerminDe
       @service = service
     end
 
+    def within?(before:, after:)
+      (after..before).cover?(self.date)
+    end
+
     def to_h
       {link: @link, date: @date}
     end

--- a/spec/termin_de/calendar_spec.rb
+++ b/spec/termin_de/calendar_spec.rb
@@ -3,28 +3,45 @@
 require 'spec_helper'
 
 describe TerminDe::Calendar do
-  # the sample calendar is used which returns 2020-09-01 as bookable
+  # the sample calendar is used which returns 2020-08-31 as bookable
   describe '#earlier?' do
     let(:options) do
-      TerminDe::Cli::Options.new(booked_termin_date, true, '12345')
+      TerminDe::Cli::Options.new(before_date, after_date, true, '12345')
     end
 
     subject { described_class.new(options).earlier? }
 
-    context 'when the booked termin is later than the available termins' do
-      let(:booked_termin_date) { Date.new(2020, 9, 2) }
+    context 'when the booked termin is within the time window' do
+      let(:after_date)  { Date.new(2020, 8, 30) }
+      let(:before_date) { Date.new(2020, 9,  1) }
 
       it { is_expected.to be_truthy }
     end
 
-    context 'when the booked termin is earlier than the available termins' do
-      let(:booked_termin_date) { Date.new(2020, 8, 31) }
+    context 'when the booked termin is before the time window' do
+      let(:after_date)  { Date.new(2020, 9, 1) }
+      let(:before_date) { Date.new(2020, 9, 2) }
 
       it { is_expected.to be_falsy }
     end
 
-    context 'when the booked termin is equal than the earlier available termin' do
-      let(:booked_termin_date) { Date.new(2020, 9, 1) }
+    context 'when the booked termin is after the time window' do
+      let(:after_date)  { Date.new(2020, 8, 29) }
+      let(:before_date) { Date.new(2020, 8, 30) }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context 'when the booked termin is equal to after date' do
+      let(:after_date)  { Date.new(2020, 8, 31) }
+      let(:before_date) { Date.new(2020, 9,  1) }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context 'when the booked termin is equal to before date' do
+      let(:after_date)  { Date.new(2020, 8, 30) }
+      let(:before_date) { Date.new(2020, 8, 31) }
 
       it { is_expected.to be_falsy }
     end


### PR DESCRIPTION
## Motivation

Some _termins_ can be booked only within a specific time window (e.g. _abmeldung_, which can be booked minimum 7 days before the departure and no later than 15 days).

This CR adds support to after date, filtering out those _termins_ that aren't within the time window [after date, before date] (exclusive)

`--after` (or shorthand `-a`) is optional. If not provided, it's set to a safe default (`1970-01-01`)